### PR TITLE
feat: add freebuff tool to known tools list

### DIFF
--- a/.changeset/add-freebuff-tool.md
+++ b/.changeset/add-freebuff-tool.md
@@ -1,0 +1,7 @@
+---
+"ai-launcher": minor
+---
+
+Add freebuff tool auto-detection support
+
+Added freebuff to KNOWN_TOOLS for automatic detection when installed. Freebuff is a free, ad-supported AI coding agent (Codebuff variant). Also includes a justfile for development task shortcuts.

--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@
 ## ✨ Features
 
 - **🔍 Fuzzy Search**: Interactive terminal UI with real-time filtering and keyboard navigation
-- **🔧 Auto-Detection**: Automatically finds installed AI CLIs (claude, gemini, agy, opencode, amp, copilot, codex, kilo, pi, droid, ollama, cursor, ccs, cmd)
+- **🔧 Auto-Detection**: Automatically finds installed AI CLIs (claude, gemini, agy, opencode, amp, copilot, codex, kilo, pi, droid, ollama, cursor, ccs, cmd, freebuff)
 - **⚡ Direct Invocation**: Skip the menu with `ai <toolname>` or fuzzy matching
 - **🏷️ Aliases**: Define short aliases for frequently used tools (e.g., `ai c` for claude)
 - **📋 Templates**: Create command shortcuts with `$@` argument/stdin placeholders
@@ -362,6 +362,7 @@ The following CLIs are auto-detected if installed and available in PATH:
 - `cursor` - Cursor AI Editor
 - `ccs` - **Claude Code Switch** (with profile detection via `ccs api list`)
 - `cmd` - Command Code CLI
+- `freebuff` - Freebuff, free ad-supported AI coding agent (Codebuff variant)
 
 **Precedence Rules:**
 

--- a/justfile
+++ b/justfile
@@ -1,0 +1,49 @@
+# AI Launcher - Development tasks
+
+# Run in development mode
+dev:
+  bun run dev
+
+# Build standalone executable to dist/ai
+build:
+  bun run build
+
+# TypeScript strict mode type checking
+typecheck:
+  bun run typecheck
+
+# Biome linting
+lint:
+  bun run lint
+
+# Auto-fix lint issues
+lint-fix:
+  bun run lint:fix
+
+# Biome format check
+format:
+  bun run format
+
+# Auto-format code
+format-fix:
+  bun run format:fix
+
+# Combined lint + format check
+check:
+  bun run check
+
+# Auto-fix lint and format
+check-fix:
+  bun run check:fix
+
+# Full CI: typecheck + check + test
+ci:
+  bun run ci
+
+# Run all unit tests
+test:
+  bun test
+
+# Release with version bump
+release:
+  bun run release:version

--- a/src/detect.test.ts
+++ b/src/detect.test.ts
@@ -214,6 +214,18 @@ describe("detectInstalledTools", () => {
     expect(pi?.description).toBe("Pi AI CLI");
   });
 
+  test("freebuff is in KNOWN_TOOLS with correct configuration", () => {
+    const freebuff = KNOWN_TOOLS.find((t) => t.name === "freebuff");
+
+    expect(freebuff).toBeDefined();
+    expect(freebuff?.name).toBe("freebuff");
+    expect(freebuff?.command).toBe("freebuff");
+    expect(freebuff?.description).toBe(
+      "Freebuff - Free ad-supported AI coding agent (Codebuff variant)"
+    );
+    expect(freebuff?.promptCommand).toBeUndefined();
+  });
+
   test("returns only installed tools from KNOWN_TOOLS", () => {
     const tools = detectInstalledTools();
 

--- a/src/detect.ts
+++ b/src/detect.ts
@@ -85,6 +85,11 @@ export const KNOWN_TOOLS: Array<{
     description: "Command Code CLI",
     promptCommand: "cmd -p",
   },
+  {
+    name: "freebuff",
+    command: "freebuff",
+    description: "Freebuff - Free ad-supported AI coding agent (Codebuff variant)",
+  },
 ];
 
 const CLI_PROXY_PROVIDERS: Array<{ name: string; description: string }> = [


### PR DESCRIPTION
## What

Add freebuff to the KNOWN_TOOLS list for auto-detection and update documentation.

## Why

Freebuff is a free, ad-supported AI coding agent (Codebuff variant) that users may have installed. Adding it enables automatic detection and launching through the ai-launcher.

## How

- Added freebuff entry to KNOWN_TOOLS array in src/detect.ts with command and description
- Updated README.md to list freebuff in the tool detection section
- Added corresponding test case to verify the tool is properly registered

## Checklist

- [x] Tests added or updated
- [x] Documentation updated
- [x] No breaking changes

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added auto-detection support for Freebuff (Codebuff variant) in the supported tools list

* **Documentation**
  * Updated README to reflect Freebuff auto-detection capability

* **Chores**
  * Added development task recipes for building, testing, linting, formatting, and release management

<!-- end of auto-generated comment: release notes by coderabbit.ai -->