### PR TITLE
feat: add grok cli to auto-detected tools

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@
 ## ✨ Features
 
 - **🔍 Fuzzy Search**: Interactive terminal UI with real-time filtering and keyboard navigation
-- **🔧 Auto-Detection**: Automatically finds installed AI CLIs (claude, gemini, agy, opencode, amp, copilot, codex, kilo, pi, droid, ollama, cursor, ccs, cmd, freebuff)
+- **🔧 Auto-Detection**: Automatically finds installed AI CLIs (claude, gemini, agy, opencode, amp, copilot, codex, kilo, pi, droid, ollama, cursor, ccs, cmd, freebuff, grok)
 - **⚡ Direct Invocation**: Skip the menu with `ai <toolname>` or fuzzy matching
 - **🏷️ Aliases**: Define short aliases for frequently used tools (e.g., `ai c` for claude)
 - **📋 Templates**: Create command shortcuts with `$@` argument/stdin placeholders
@@ -327,6 +327,7 @@ Different AI CLIs accept prompts in different ways. The `promptCommand` and `pro
 | Tool       | Prompt Command                                     | Why                                               |
 | ---------- | -------------------------------------------------- | ------------------------------------------------- |
 | `claude`   | `claude --permission-mode plan -p 'prompt'`        | Uses plan mode for read-only analysis             |
+| `grok`     | `grok --permission-mode plan -p 'prompt'`          | Uses plan mode for read-only analysis             |
 | `ccs`      | `ccs <profile> --permission-mode plan -p 'prompt'` | Uses plan mode for read-only analysis             |
 | `opencode` | `echo 'prompt' &#124; opencode run`                | First arg is treated as project path, needs stdin |
 | `amp`      | `echo 'prompt' &#124; amp -x`                      | Execute mode works best with stdin                |
@@ -363,6 +364,7 @@ The following CLIs are auto-detected if installed and available in PATH:
 - `ccs` - **Claude Code Switch** (with profile detection via `ccs api list`)
 - `cmd` - Command Code CLI
 - `freebuff` - Freebuff, free ad-supported AI coding agent (Codebuff variant)
+- `grok` - xAI Grok Build CLI
 
 **Precedence Rules:**
 

--- a/docs/_README.md
+++ b/docs/_README.md
@@ -19,7 +19,7 @@
 ## ✨ Features
 
 - **🔍 Fuzzy Search**: Interactive terminal UI with real-time filtering and keyboard navigation
-- **🔧 Auto-Detection**: Automatically finds installed AI CLIs (claude, gemini, agy, opencode, amp, copilot, codex, kilo, pi, droid, ollama, cursor, ccs, cmd, freebuff)
+- **🔧 Auto-Detection**: Automatically finds installed AI CLIs (claude, gemini, agy, opencode, amp, copilot, codex, kilo, pi, droid, ollama, cursor, ccs, cmd, freebuff, grok)
 - **⚡ Direct Invocation**: Skip the menu with `ai <toolname>` or fuzzy matching
 - **🏷️ Aliases**: Define short aliases for frequently used tools (e.g., `ai c` for claude)
 - **📋 Templates**: Create command shortcuts with `$@` argument/stdin placeholders
@@ -327,6 +327,7 @@ Different AI CLIs accept prompts in different ways. The `promptCommand` and `pro
 | Tool       | Prompt Command                                     | Why                                               |
 | ---------- | -------------------------------------------------- | ------------------------------------------------- |
 | `claude`   | `claude --permission-mode plan -p 'prompt'`        | Uses plan mode for read-only analysis             |
+| `grok`     | `grok --permission-mode plan -p 'prompt'`          | Uses plan mode for read-only analysis             |
 | `ccs`      | `ccs <profile> --permission-mode plan -p 'prompt'` | Uses plan mode for read-only analysis             |
 | `opencode` | `echo 'prompt' &#124; opencode run`                | First arg is treated as project path, needs stdin |
 | `amp`      | `echo 'prompt' &#124; amp -x`                      | Execute mode works best with stdin                |
@@ -363,6 +364,7 @@ The following CLIs are auto-detected if installed and available in PATH:
 - `ccs` - **Claude Code Switch** (with profile detection via `ccs api list`)
 - `cmd` - Command Code CLI
 - `freebuff` - Freebuff, free ad-supported AI coding agent (Codebuff variant)
+- `grok` - xAI Grok Build CLI
 
 **Precedence Rules:**
 

--- a/src/detect.test.ts
+++ b/src/detect.test.ts
@@ -226,6 +226,16 @@ describe("detectInstalledTools", () => {
     expect(freebuff?.promptCommand).toBeUndefined();
   });
 
+  test("grok is in KNOWN_TOOLS with correct configuration", () => {
+    const grok = KNOWN_TOOLS.find((t) => t.name === "grok");
+
+    expect(grok).toBeDefined();
+    expect(grok?.name).toBe("grok");
+    expect(grok?.command).toBe("grok");
+    expect(grok?.description).toBe("xAI Grok Build CLI");
+    expect(grok?.promptCommand).toBe("grok --permission-mode plan -p");
+  });
+
   test("returns only installed tools from KNOWN_TOOLS", () => {
     const tools = detectInstalledTools();
 

--- a/src/detect.ts
+++ b/src/detect.ts
@@ -90,6 +90,12 @@ export const KNOWN_TOOLS: Array<{
     command: "freebuff",
     description: "Freebuff - Free ad-supported AI coding agent (Codebuff variant)",
   },
+  {
+    name: "grok",
+    command: "grok",
+    description: "xAI Grok Build CLI",
+    promptCommand: "grok --permission-mode plan -p",
+  },
 ];
 
 const CLI_PROXY_PROVIDERS: Array<{ name: string; description: string }> = [

--- a/src/index.ts
+++ b/src/index.ts
@@ -318,6 +318,7 @@ async function main() {
     console.error("   • opencode  - OpenCode AI assistant");
     console.error("   • amp       - Sourcegraph Amp CLI");
     console.error("   • codex     - OpenAI Codex CLI");
+    console.error("   • grok      - xAI Grok Build CLI");
     console.error("   • ollama    - Ollama CLI");
     console.error("   • ccs       - Claude Code Switch");
     console.error("\n📝 Or add custom tools to ~/.config/ai-launcher/config.json");


### PR DESCRIPTION
## What

Add xAI Grok Build CLI (`grok`) to ai-launcher's auto-detected tool list.

- Register `grok` in `KNOWN_TOOLS` (`src/detect.ts`)
- Add unit test for grok configuration (`src/detect.test.ts`)
- Include grok in the "no tools found" install hints (`src/index.ts`)
- Document grok in README auto-detection and git diff prompt tables (`README.md`, `docs/_README.md`)

## Why

Users with the Grok Build CLI installed could not launch or select it through ai-launcher. Supporting grok keeps the launcher aligned with other headless-capable AI CLIs (Claude, Gemini, Codex) and enables diff-analysis workflows via templates and `--diff-*` flags.

## How

- Detect `grok` on PATH like other known tools
- Set `promptCommand` to `grok --permission-mode plan -p` so `--diff-staged` and `--diff-commit` use plan mode for read-only analysis, matching the Claude/CCS pattern
- No config schema changes; auto-detection only

## Checklist

- [x] Tests added or updated
- [x] Documentation updated
- [x] No breaking changes (or breaking changes documented above)