### PR TITLE
refactor: derive install hints from KNOWN_TOOLS

### DIFF
--- a/src/detect.test.ts
+++ b/src/detect.test.ts
@@ -6,6 +6,7 @@ import {
   formatSuggestedInstallHints,
   getSuggestedInstallTools,
   KNOWN_TOOLS,
+  type KnownToolDefinition,
   parseCcsApiList,
   SUGGESTED_INSTALL_TOOL_NAMES,
 } from "./detect";
@@ -160,7 +161,7 @@ describe("detectInstalledTools", () => {
   });
 
   test("agy is in KNOWN_TOOLS with correct configuration", () => {
-    const agy = KNOWN_TOOLS.find((t) => t.name === "agy");
+    const agy = KNOWN_TOOLS.find((t) => t.name === "agy") as KnownToolDefinition | undefined;
 
     expect(agy).toBeDefined();
     expect(agy?.name).toBe("agy");
@@ -218,7 +219,9 @@ describe("detectInstalledTools", () => {
   });
 
   test("freebuff is in KNOWN_TOOLS with correct configuration", () => {
-    const freebuff = KNOWN_TOOLS.find((t) => t.name === "freebuff");
+    const freebuff = KNOWN_TOOLS.find((t) => t.name === "freebuff") as
+      | KnownToolDefinition
+      | undefined;
 
     expect(freebuff).toBeDefined();
     expect(freebuff?.name).toBe("freebuff");
@@ -253,12 +256,6 @@ describe("detectInstalledTools", () => {
 });
 
 describe("suggested install tools", () => {
-  test("every suggested name exists in KNOWN_TOOLS", () => {
-    for (const name of SUGGESTED_INSTALL_TOOL_NAMES) {
-      expect(KNOWN_TOOLS.some((t) => t.name === name)).toBe(true);
-    }
-  });
-
   test("getSuggestedInstallTools returns curated tools plus ccs", () => {
     const tools = getSuggestedInstallTools();
     const names = tools.map((t) => t.name);

--- a/src/detect.test.ts
+++ b/src/detect.test.ts
@@ -3,8 +3,11 @@ import {
   detectCliProxyProfiles,
   detectGhCopilot,
   detectInstalledTools,
+  formatSuggestedInstallHints,
+  getSuggestedInstallTools,
   KNOWN_TOOLS,
   parseCcsApiList,
+  SUGGESTED_INSTALL_TOOL_NAMES,
 } from "./detect";
 
 const CCS_API_LIST_OUTPUT = `CCS API Profiles
@@ -246,6 +249,33 @@ describe("detectInstalledTools", () => {
       const isKnown = KNOWN_TOOLS.some((k) => k.name === tool.name);
       expect(isCcs || isGhCopilot || isKnown).toBe(true);
     }
+  });
+});
+
+describe("suggested install tools", () => {
+  test("every suggested name exists in KNOWN_TOOLS", () => {
+    for (const name of SUGGESTED_INSTALL_TOOL_NAMES) {
+      expect(KNOWN_TOOLS.some((t) => t.name === name)).toBe(true);
+    }
+  });
+
+  test("getSuggestedInstallTools returns curated tools plus ccs", () => {
+    const tools = getSuggestedInstallTools();
+    const names = tools.map((t) => t.name);
+
+    expect(names).toEqual([...SUGGESTED_INSTALL_TOOL_NAMES, "ccs"]);
+    expect(tools[0]?.description).toBe("Anthropic Claude CLI");
+    expect(tools.at(-1)?.description).toBe("CCS CLI (Claude Code Switch)");
+  });
+
+  test("formatSuggestedInstallHints aligns names and includes grok", () => {
+    const lines = formatSuggestedInstallHints();
+
+    expect(lines).toHaveLength(SUGGESTED_INSTALL_TOOL_NAMES.length + 1);
+    expect(lines.some((line) => line.includes("grok") && line.includes("xAI Grok Build CLI"))).toBe(
+      true
+    );
+    expect(lines.every((line) => line.startsWith("   • "))).toBe(true);
   });
 });
 

--- a/src/detect.ts
+++ b/src/detect.ts
@@ -1,14 +1,16 @@
 import { spawnSync } from "node:child_process";
 import type { Tool } from "./types";
 
-export const KNOWN_TOOLS: Array<{
+export type KnownToolDefinition = {
   name: string;
   command: string;
   description: string;
   execCommand?: string;
   promptCommand?: string;
   promptUseStdin?: boolean;
-}> = [
+};
+
+export const KNOWN_TOOLS = [
   {
     name: "claude",
     command: "claude",
@@ -96,7 +98,9 @@ export const KNOWN_TOOLS: Array<{
     description: "xAI Grok Build CLI",
     promptCommand: "grok --permission-mode plan -p",
   },
-];
+] as const satisfies readonly KnownToolDefinition[];
+
+export type KnownToolName = (typeof KNOWN_TOOLS)[number]["name"];
 
 /** Curated subset of KNOWN_TOOLS shown when no AI tools are detected. */
 export const SUGGESTED_INSTALL_TOOL_NAMES = [
@@ -107,7 +111,7 @@ export const SUGGESTED_INSTALL_TOOL_NAMES = [
   "codex",
   "grok",
   "ollama",
-] as const;
+] as const satisfies readonly KnownToolName[];
 
 export type SuggestedInstallTool = {
   name: string;
@@ -119,16 +123,13 @@ const CCS_SUGGESTED_INSTALL_TOOL: SuggestedInstallTool = {
   description: "CCS CLI (Claude Code Switch)",
 };
 
-function findKnownToolByName(name: string): (typeof KNOWN_TOOLS)[number] | undefined {
-  return KNOWN_TOOLS.find((t) => t.name === name);
+function findKnownToolByName(name: KnownToolName): KnownToolDefinition {
+  return KNOWN_TOOLS.find((t) => t.name === name) as KnownToolDefinition;
 }
 
 export function getSuggestedInstallTools(): SuggestedInstallTool[] {
   const fromKnown = SUGGESTED_INSTALL_TOOL_NAMES.map((name) => {
     const tool = findKnownToolByName(name);
-    if (!tool) {
-      throw new Error(`Suggested install tool "${name}" is not in KNOWN_TOOLS`);
-    }
     return { name: tool.name, description: tool.description };
   });
 
@@ -254,7 +255,8 @@ export function detectCliProxyProfiles(): Tool[] {
 export function detectInstalledTools(): Tool[] {
   const detected: Tool[] = [];
 
-  for (const tool of KNOWN_TOOLS) {
+  for (const entry of KNOWN_TOOLS) {
+    const tool: KnownToolDefinition = entry;
     if (commandExists(tool.command)) {
       detected.push({
         name: tool.name,

--- a/src/detect.ts
+++ b/src/detect.ts
@@ -98,6 +98,50 @@ export const KNOWN_TOOLS: Array<{
   },
 ];
 
+/** Curated subset of KNOWN_TOOLS shown when no AI tools are detected. */
+export const SUGGESTED_INSTALL_TOOL_NAMES = [
+  "claude",
+  "agy",
+  "opencode",
+  "amp",
+  "codex",
+  "grok",
+  "ollama",
+] as const;
+
+export type SuggestedInstallTool = {
+  name: string;
+  description: string;
+};
+
+const CCS_SUGGESTED_INSTALL_TOOL: SuggestedInstallTool = {
+  name: "ccs",
+  description: "CCS CLI (Claude Code Switch)",
+};
+
+function findKnownToolByName(name: string): (typeof KNOWN_TOOLS)[number] | undefined {
+  return KNOWN_TOOLS.find((t) => t.name === name);
+}
+
+export function getSuggestedInstallTools(): SuggestedInstallTool[] {
+  const fromKnown = SUGGESTED_INSTALL_TOOL_NAMES.map((name) => {
+    const tool = findKnownToolByName(name);
+    if (!tool) {
+      throw new Error(`Suggested install tool "${name}" is not in KNOWN_TOOLS`);
+    }
+    return { name: tool.name, description: tool.description };
+  });
+
+  return [...fromKnown, CCS_SUGGESTED_INSTALL_TOOL];
+}
+
+export function formatSuggestedInstallHints(): string[] {
+  const tools = getSuggestedInstallTools();
+  const nameWidth = Math.max(...tools.map((t) => t.name.length));
+
+  return tools.map((tool) => `   • ${tool.name.padEnd(nameWidth)} - ${tool.description}`);
+}
+
 const CLI_PROXY_PROVIDERS: Array<{ name: string; description: string }> = [
   { name: "gemini", description: "Google Gemini (OAuth)" },
   { name: "codex", description: "OpenAI Codex (OAuth)" },

--- a/src/index.ts
+++ b/src/index.ts
@@ -6,7 +6,7 @@ import { existsSync, readFileSync, writeFileSync } from "node:fs";
 import { dirname, isAbsolute, normalize, resolve } from "node:path";
 import { executeDiffCommand, parseDiffArgs } from "./cli/diff";
 import { loadConfig } from "./config";
-import { detectInstalledTools, mergeTools } from "./detect";
+import { detectInstalledTools, formatSuggestedInstallHints, mergeTools } from "./detect";
 import { fuzzySelect, promptForInput, toSelectableItems } from "./fuzzy-select";
 import { getColoredLogo } from "./logo";
 import { findToolByName } from "./lookup";
@@ -313,14 +313,9 @@ async function main() {
   if (items.length === 0) {
     console.error("❌ No AI tools found!\n");
     console.error("💡 Install one or more of these tools:");
-    console.error("   • claude    - Anthropic Claude CLI");
-    console.error("   • agy       - Google Antigravity CLI");
-    console.error("   • opencode  - OpenCode AI assistant");
-    console.error("   • amp       - Sourcegraph Amp CLI");
-    console.error("   • codex     - OpenAI Codex CLI");
-    console.error("   • grok      - xAI Grok Build CLI");
-    console.error("   • ollama    - Ollama CLI");
-    console.error("   • ccs       - Claude Code Switch");
+    for (const line of formatSuggestedInstallHints()) {
+      console.error(line);
+    }
     console.error("\n📝 Or add custom tools to ~/.config/ai-launcher/config.json");
     process.exit(1);
   }


### PR DESCRIPTION
## What

Derive the "no AI tools found" install hints from `KNOWN_TOOLS` instead of hardcoding names and descriptions in `index.ts`.

- `SUGGESTED_INSTALL_TOOL_NAMES` — curated subset in `detect.ts`
- `getSuggestedInstallTools()` / `formatSuggestedInstallHints()` — lookup + formatting
- Tests for registry consistency and hint output

## Why

Follow-up from code review on #59: adding a tool required parallel edits in `KNOWN_TOOLS`, `index.ts`, and README. Descriptions in the error path now come from the canonical registry; only the curated name list needs updating for new suggested tools.

## How

- Map `SUGGESTED_INSTALL_TOOL_NAMES` to `KNOWN_TOOLS` entries (throws if a name is missing)
- Keep `ccs` as a separate constant (not in `KNOWN_TOOLS`, detected via `commandExists("ccs")`)
- `opencode` hint text now matches registry: "OpenCode CLI" (was "OpenCode AI assistant")

## Checklist

- [x] Tests added or updated
- [ ] Documentation updated (no user-facing doc change; error text only)
- [x] No breaking changes