### PR TITLE
feat: add Mi AI (mimo) CLI support

### DIFF
--- a/.planning/codebase/ARCHITECTURE.md
+++ b/.planning/codebase/ARCHITECTURE.md
@@ -1,140 +1,204 @@
 # Architecture
 
-**Analysis Date:** 2026-01-31
+**Analysis Date:** 2026-06-04
 
 ## Pattern Overview
 
-**Overall:** Modular single-binary CLI with layered responsibilities
+**Overall:** Modular procedural CLI with focused pure and side-effect modules, strict TypeScript, security guards before execution, and co-located tests. No heavy frameworks or classes beyond error types.
 
 **Key Characteristics:**
-- Flat `src/` layout — each module owns one responsibility, no deep nesting (except `src/cli/`)
-- Synchronous shell execution (`spawnSync`) throughout — simplifies control flow for a CLI tool
-- Immutable data flow — config and tool objects are read, validated, then passed down; no shared mutable state
-- Security-first command execution — allowlist validation before any shell invocation
+- Single async main() entry that dispatches on argv patterns (direct name, -- sep, no arg fuzzy, special --diff-*, upgrade) before heavy work where possible. `src/index.ts:287`
+- Data transformed through pipeline: raw config/detect -> merged tools -> SelectableItem[] -> lookup or fuzzy -> launch
+- Security by construction: allowlist + deny patterns for commands, validated refs/paths/args, no eval, shell only for final controlled spawn
+- Detection merges user config (precedence) with runtime PATH checks and special subproc probes (ccs api list)
+- Interactive TUI uses raw stdin/stdout ANSI without external UI libs; fuzzy uses fuse.js + custom pre-filters
+- Build produces standalone via bun --compile; version injected at build
+- Follows AGENTS.md guidelines: guard clauses, explicit returns, no any, node: prefix, verbatim type imports, small reversible steps
 
 ## Layers
 
-**Entry Point / Routing:**
-- Purpose: Parse CLI arguments, route to the correct execution path
-- Location: `src/index.ts`
-- Contains: Argument parsing, tool launching (`launchTool`, `launchToolWithPrompt`), main async entry
-- Depends on: lookup, fuzzy-select, config, detect, cli/diff, template
-- Used by: Bun runtime (binary entry)
+**CLI Orchestration / Entry Layer:**
+- Purpose: Argument parsing, flow control, stdio handling (incl stdin capture for templates), process spawning for tools, error exits, special modes (help, version, upgrade, diff)
+- Location: `src/index.ts` (main orchestration and launch*), `src/cli/diff.ts` (diff specific parse/execute)
+- Contains: main(), launchTool, launchToolWithPrompt, handleChildProcessError, validate* helpers, showHelp, readStdin, isValidOutputPath etc.
+- Depends on: all lower layers (config, detect, fuzzy, lookup, template, cli/diff, upgrade, logo, version)
+- Used by: shell invocation of the `ai` bin
 
-**Tool Management:**
-- Purpose: Discover installed AI CLIs and load user configuration
-- Location: `src/detect.ts`, `src/config.ts`
-- Contains: Which-based detection, CCS profile parsing, JSON config load/save/validate
-- Depends on: types, node:child_process, node:fs
-- Used by: index.ts
+**Configuration / Persistence Layer:**
+- Purpose: Filesystem config load (with migrate from legacy ai-switcher), validation, default creation with rich templates
+- Location: `src/config.ts`
+- Contains: loadConfig, validateConfig, validateTemplate, validateTool, formatValidationErrors, ensureConfigDir, createDefaultConfig, migrateOldConfig, DEFAULT_CONFIG, CONFIG_PATH consts
+- Depends on: `src/template.ts` (isSafeCommand), `src/types.ts`, node:fs, node:os, node:path
+- Used by: `src/index.ts:306`, template tests via validateConfig
 
-**Selection & Lookup:**
-- Purpose: Match user input to a tool — by name, alias, or interactive fuzzy search
+**Detection Layer:**
+- Purpose: Runtime discovery of AI CLIs via PATH (which), special CCS profile extraction, gh-copilot probe, proxy profiles; merge with user config (dedup, precedence)
+- Location: `src/detect.ts`
+- Contains: KNOWN_TOOLS (15+ entries with optional promptCommand/promptUseStdin/execCommand), detectInstalledTools, mergeTools, detectCcsProfiles, parseCcsApiList, detectGhCopilot, detectCliProxyProfiles, formatSuggestedInstallHints, commandExists
+- Depends on: node:child_process (spawnSync for which + ccs api + gh), `src/types.ts`
+- Used by: `src/index.ts:307`
+
+**Lookup + Fuzzy Selection Layer:**
+- Purpose: Name/alias/fuzzy resolution (exact > alias > suffix > substring > fuse) with ambiguity scoring; full interactive raw-mode TUI with live fuse filter, key nav, compact mode, [T] template indicator
 - Location: `src/lookup.ts`, `src/fuzzy-select.ts`
-- Contains: Priority-based lookup (exact → alias → suffix → substring → fuzzy), interactive TUI with Fuse.js
-- Depends on: types, fuse.js
-- Used by: index.ts, cli/diff.ts
+- Contains: findToolByName (returns LookupResult), fuzzySelect, promptForInput, toSelectableItems
+- Depends on: fuse.js (two instances: lookup keys:["name"], fuzzy keys:["name","description","aliases"]), `src/types.ts`
+- Used by: `src/index.ts:339`, `src/index.ts:355`, `src/cli/diff.ts:165`, `src/cli/diff.ts:181`, tests
 
-**Git Diff Analysis:**
-- Purpose: Extract git diffs and build AI analysis prompts
-- Location: `src/git-diff.ts`, `src/cli/diff.ts`, `src/prompts.ts`
-- Contains: Git command execution, argument parsing for `--diff-staged`/`--diff-commit`, prompt assembly
-- Depends on: errors, lookup, fuzzy-select, types
-- Used by: index.ts
-
-**Template System:**
-- Purpose: Validate and execute pre-configured command templates
+**Template Safety / Execution Layer:**
+- Purpose: Command sanitization (prevent injection), template expansion ($@ handling), shell parsing helper
 - Location: `src/template.ts`
-- Contains: Command validation (allowlist regex), `$@` argument substitution, shell-safe parsing
-- Depends on: types
-- Used by: index.ts
+- Contains: isSafeCommand (SAFE_COMMAND_PATTERN allow + DANGEROUS_PATTERNS deny list incl && || ; $( ` sudo rm >), buildTemplateCommand, parseTemplateCommand (quote-aware split)
+- Depends on: none (pure)
+- Used by: `src/config.ts:149` (validate), `src/index.ts:149` (launch), `src/index.ts:200`, tests (dynamic import)
 
-**Utilities:**
-- Purpose: Supporting concerns — versioning, upgrades, branding
-- Location: `src/upgrade.ts`, `src/logo.ts`, `src/version.ts`
-- Contains: GitHub release fetching, binary replacement with checksum verification, ASCII art
-- Depends on: node:https, node:crypto, node:fs
-- Used by: index.ts
+**Diff / Prompt / Git Layer:**
+- Purpose: Git repo/diff extraction (staged or ref), analysis prompt construction, output file validation+write, launch via promptCommand or stdin pipe
+- Location: `src/git-diff.ts`, `src/prompts.ts`, `src/errors.ts`, `src/cli/diff.ts`
+- Contains: getGitDiff (with buffer limits), ensureGitRepository/isGitRepository, buildDiffAnalysisPrompt, GitDiffError + subclasses (NotGitRepositoryError etc), FileOutputError, parseDiffArgs, executeDiffCommand, isValidGitRef
+- Depends on: node:child_process, `src/errors.ts`, `src/git-diff.ts`, `src/prompts.ts`, `src/lookup.ts`, `src/fuzzy-select.ts` (type), types
+- Used by: `src/index.ts:323` (parse + execute if --diff-*)
 
-**Error Hierarchy:**
-- Purpose: Typed error classes for git diff operations
-- Location: `src/errors.ts`
-- Contains: `GitDiffError` base → `NotGitRepositoryError`, `InvalidGitRefError`, `NoChangesError`, `GitCommandError`
-- Depends on: nothing
-- Used by: git-diff.ts, cli/diff.ts
+**Self-Upgrade Layer:**
+- Purpose: Cross-platform binary self-update from GitHub releases (fetch, checksum sha256, atomic rename with backup, permission handling)
+- Location: `src/upgrade.ts`
+- Contains: upgrade (async), findBinaryPath (which + common paths + execPath), platform/arch artifact logic
+- Depends on: node:child_process (execSync), node:fs/promises, node:crypto, node:os, node:path, semver (gte), `src/version.ts`
+- Used by: `src/index.ts:299` (early, before config)
+
+**Supporting / Types Layer:**
+- Purpose: Shared data shapes, branding, build-time version
+- Location: `src/types.ts`, `src/logo.ts`, `src/version.ts`
+- Contains: Tool, Template, Config, SelectableItem, AuthType, ConfigValidationError, LookupResult, SelectionResult, logo variants + getColoredLogo, VERSION const
+- version generated: `scripts/build.sh:4` (from package.json), also in release CI; biome ignores `biome.json:63`
+- Depends: semver only in upgrade
 
 ## Data Flow
 
-**Standard tool launch:**
-1. `index.ts` parses argv; extracts tool query and remaining args
-2. `lookup.ts` matches query → tool (or falls back to `fuzzy-select.ts` interactive TUI)
-3. `template.ts` validates the command if it's a template invocation
-4. `index.ts` calls `spawnSync` with validated command + args, `shell: true`, `stdio: inherit`
+**Primary Non-Diff Flow (`src/index.ts:287`):**
+1. argv = process.argv.slice(2)
+2. Early exits: --help/-h, --version/-v, "upgrade" (await upgrade)
+3. stdinContent = readStdin() (only if !tty)
+4. config = loadConfig()  // may migrate/create/throw validation
+5. detectedTools = detectInstalledTools()
+6. allTools = mergeTools(config.tools, detectedTools)  // user config wins, dedup name+command
+7. items = toSelectableItems(allTools, config.templates)  // tools first then templates
+8. lookupItems = items
+9. if no items: print hints + exit
+10. Parse for --diff-* (separate branch)
+11. Handle "--" separator: beforeDash empty? -> fuzzySelect then launch(after); else lookup(before) then launch(after)
+12. args.length >0 ? lookup(args[0]) + launch(slice(1)) : fuzzySelect() then (if template+$@ prompt input else launch)
+13. launchTool always: isSafe + validateArgs + ($@ replace or append) + split + spawnSync(shell) + handle error + exit(status)
 
-**Diff analysis launch:**
-1. `index.ts` detects `--diff-staged` or `--diff-commit` flag, delegates to `cli/diff.ts`
-2. `cli/diff.ts` calls `git-diff.ts` to run `git diff` via `spawnSync`
-3. `prompts.ts` builds an analysis prompt embedding the diff text
-4. Tool is selected (by name arg or fuzzy select), then launched with the prompt via single-quoted shell arg
+**Diff Flow (`src/index.ts:323`, `src/cli/diff.ts:106`):**
+- parseDiffArgs -> options + flagIndex
+- ensureGitRepository (or user msg)
+- diff = getGitDiff (staged or ref; throws specific)
+- prompt = buildDiffAnalysisPrompt(diff, ref, custom)
+- if argsBeforeFlag empty: fuzzy -> item; else lookup(item)
+- toolCmd = item.promptCommand ?? item.command; useStdin = ...
+- launchToolWithPrompt(toolCmd, prompt, useStdin, outputFile?)  // which may pipe input or sh -c 'cmd '\''escaped'\'' , then if outputFile write stdout + exit
 
-**Upgrade flow:**
-1. `upgrade.ts` fetches latest release metadata from GitHub API
-2. Compares versions with `semver`
-3. Downloads platform binary, verifies SHA256 checksum
-4. Backs up current binary, atomically replaces it
+**Config Load Flow (`src/config.ts:248`):**
+migrateOldConfig (copy if old exists new absent) -> if !exists createDefault (with 8 DEFAULT_TEMPLATES) -> read/parse -> validateConfig (tools+templates, isSafe, alias array, single $@ etc) -> throw formatted or return
 
-**State Management:**
-- No shared mutable state between modules
-- User config is the only persistent state — loaded once at startup, written only on explicit save
-- Terminal raw-mode state in `fuzzy-select.ts` is scoped to the interactive selection lifecycle
+**Lookup Heuristics (in order, `src/lookup.ts:11`):**
+exact name (ci) -> alias (ci) -> unique suffix (e.g. "mm" -> "ccs:mm") -> unique substring -> fuse (threshold 0.4); if >=2 results check score gap <0.05 for ambiguous (list candidates) else best if score ok.
+
+**State:** Ephemeral only. No in-memory cache beyond width cache in fuzzy. Config read once per run. TTY raw mode only during fuzzy/prompt, restored on exit/cancel.
+
+**Spawn Points:** launchTool (inherit), launchToolWithPrompt (pipe or sh -c for prompt; optional fs write for --diff-output after validate no-abs no-.. no-protected).
 
 ## Key Abstractions
 
-**Tool:**
-- Purpose: Represents a detected or configured AI CLI assistant
-- Examples: `src/types.ts` (`Tool` interface), populated by `src/detect.ts`
-- Pattern: Plain data interface; no methods
+**SelectableItem (`src/types.ts:30`):**
+- Purpose: Common representation for both Tool and Template enabling uniform fuzzy/lookup/launch/diff paths
+- Examples: produced by `src/fuzzy-select.ts:9` (toSelectableItems), consumed everywhere
+- Pattern: Structural adapter / discriminated by isTemplate bool + optional prompt* fields
 
-**SelectableItem:**
-- Purpose: Unified item shape for both tools and templates in the fuzzy selector
-- Examples: `src/types.ts`, used in `fuzzy-select.ts` and `lookup.ts`
-- Pattern: Discriminated union via `type` field (`"tool" | "template"`)
+**Tool (`src/types.ts:3`) / Template (`src/types.ts:13`):**
+- Purpose: User or detected AI invocation spec; templates support $@ placeholder
+- Persisted in `~/.config/ai-launcher/config.json` (validated on load)
+- Optional fields for diff: promptCommand, promptUseStdin (to choose how to send analysis prompt)
 
-**LookupResult / SelectionResult:**
-- Purpose: Result-object pattern — success/failure without exceptions in the happy path
-- Examples: `src/lookup.ts` (`LookupResult`), `src/fuzzy-select.ts` (`SelectionResult`)
-- Pattern: `{ success: true, item }` or `{ success: false, error }`
+**LookupResult (`src/lookup.ts:4`):**
+- Purpose: Either success+item or failure+error (+optional candidates for ambiguity UI)
+- Pattern: Result type (no throw for lookup)
+
+**Git* Errors (`src/errors.ts`):**
+- Hierarchy: GitDiffError base, NotGitRepositoryError, InvalidGitRefError, NoChangesError, GitCommandError, plus FileOutputError
+- Used for typed catch in diff execute `src/cli/diff.ts:119`
+
+**Safety Guard `isSafeCommand` (`src/template.ts:22`):**
+- Central allow/deny used for both runtime launch and config acceptance
 
 ## Entry Points
 
-**CLI binary:**
-- Location: `src/index.ts` → compiled to `dist/ai`
-- Triggers: User runs `ai [tool] [args...]`
-- Responsibilities: Argument parsing, routing, tool launching
+**Runtime Binary:**
+- Location: `package.json:8` ("bin": {"ai": "./dist/ai"}), produced by `bun build src/index.ts --compile` (local: `scripts/build.sh:9`; CI matrix: `.github/workflows/release.yml:63`)
+- Triggers: any `ai` in PATH, `bun run src/index.ts ...`
+- Responsibilities: shebang `#!/usr/bin/env bun`, runs main().catch
 
-**Build script:**
-- Location: `scripts/build.sh`
-- Triggers: `bun run build`
-- Responsibilities: Generate `src/version.ts`, compile standalone binary
+**Development:**
+- `bun run dev` (package.json:12) executes src/index.ts directly
+- justfile mirrors (just dev, build, etc.)
+
+**CI / Checks:**
+- `.github/workflows/ci.yml:19`: bun install, check (biome), typecheck, test (no build)
+- Pre-commit: scripts/pre-commit (biome --staged), prek.toml (typecheck + biome on .ts)
+
+**Release / Build:**
+- Tag push triggers `.github/workflows/release.yml`: version gen, cross-compile matrix (bun-linux/mac/win targets), checksums, gh-release with artifacts + install notes, then homebrew tap update
+- `scripts/build.sh`: also gens version.ts then compile (for local/manual)
+
+**Upgrade:**
+- `ai upgrade` early path `src/index.ts:299` before any config/detect
+
+**Installers:**
+- `install.sh`: standalone curl sh that downloads matching artifact + checksum (similar logic to upgrade)
+- Homebrew: `HomebrewFormula/ai.rb` downloads per-arch and installs as "ai"
 
 ## Error Handling
 
-**Strategy:** Typed custom errors for git operations; guard clauses and early exits elsewhere
+**Strategy:** Explicit process.exit with small set of codes; user-friendly console.error; never let unhandled reach top except main catcher. Specific typed errors only for git-diff domain.
 
 **Patterns:**
-- `errors.ts` hierarchy for git-related failures — caught by type in `cli/diff.ts` for user-friendly messages
-- `process.exit(1)` for unrecoverable CLI errors after printing to stderr
-- Result objects (`LookupResult`, `SelectionResult`) avoid throwing in lookup/selection paths
-- Top-level `main().catch()` in `index.ts` catches any unhandled errors
+- Guard clauses at top of funcs (null/empty/unsafe -> early exit or error result) e.g. `src/index.ts:149`, `src/lookup.ts:12`
+- Validation at boundaries: config load throws, launch pre-checks exit(1), parseDiff throws GitDiffError
+- Spawn result check: handleChildProcessError looks for .error or .signal
+- Diff: try/catch specific subclasses -> print guidance + process.exit(1); rethrow others
+- main: `main().catch((err) => { console.error(err instanceof Error ? err.message : err); process.exit(1); })` `src/index.ts:402`
+- Defined codes: SUCCESS=0, VALIDATION=1, FILE_WRITE=2, PROCESS=3 `src/index.ts:17`
+- Upgrade and fetch paths have broad try/catch -> error msg + exit(1); cleanup on failure (restore backup)
 
 ## Cross-Cutting Concerns
 
-**Logging:** `console.error` for errors, `console.log` for user-facing output. No logging framework.
+**Logging / Output:** Pure console: log for progress ("Running: ", "Analyzing...", success save msg); error for failures/hints. No structured logs or levels. Colored only via logo and inline CSI in fuzzy-select.
 
-**Validation:** Regex allowlists validate commands (`SAFE_COMMAND_PATTERN`), arguments (max 200 chars, no shell metacharacters), and git refs (no leading `-`).
+**Validation:** Defense in depth
+- Command: isSafeCommand (template + config), simpler regex in validateTool
+- Args: validateArguments (safe charset + len<=200)
+- Git ref: isValidGitRef (charset + no leading- + no .. + no metachars)
+- Output path: isValidOutputPath (relative, no .., no leading ., no protected dirs like .git /etc /root etc) + exists check
+- Config schema + semantics on every load
+- Prompt count: at most one $@ , not starting with it
 
-**Authentication:** Not applicable — this tool launches other authenticated CLIs; it holds no credentials itself.
+**Security:**
+- Allowlist over denylist primary
+- No user input directly to shell without escaping (only ' -> '\'' for prompts in sh -c)
+- Templates validated same as runtime
+- Stdin only read when !isTTY (pipes)
+- Output writes only after dir exists + path safe
+- Upgrade uses checksums when present
+
+**Auth / External:** None handled internally; metadata (authType, prompt*) passed through for consumer CLIs (claude plan mode etc). CCS profiles carry authType.
+
+**Testing Strategy:** bun:test, test behavior not impl; co-located *.test.ts; extract pure helpers for unit (e.g. validate fns, parse, substitute mocks); run real detect/isGit in tests (accept env); cover security cases, ambiguity, edge parses extensively.
+
+**Performance / Env:** Bun for fast startup/TS exec/compile; small dep set (fuse, semver); tty width cache; buffer limits on diff (10MB); fuse threshold tuned.
+
+**Extensibility Notes:** Add to KNOWN_TOOLS for auto-detect; user tools/templates in config.json override; new --diff- or modes via argv in index + cli/ subdir; prompt* fields per-tool for stdin vs arg prompt delivery.
 
 ---
 
-*Architecture analysis: 2026-01-31*
+*Architecture analysis: 2026-06-04*

--- a/.planning/codebase/CONCERNS.md
+++ b/.planning/codebase/CONCERNS.md
@@ -1,161 +1,276 @@
 # Codebase Concerns
 
-**Analysis Date:** 2026-01-31
+**Analysis Date:** 2026-06-04
 
 ## Tech Debt
 
-**Duplicated Validation Patterns:**
-- Issue: Command/argument validation regex patterns are defined independently in multiple modules with slight differences
-- Files: `src/index.ts` (`validateArguments`), `src/config.ts` (`validateTool`), `src/detect.ts` (`validateCommandName`), `src/template.ts` (`SAFE_COMMAND_PATTERN`)
-- Impact: Changing security rules requires updating multiple locations; risk of drift
-- Fix approach: Extract shared validation functions into a `src/validate.ts` module
+**[Validation logic duplication in tests]:**
+- Issue: Multiple test files duplicate and reimplement core validation functions (validateArguments, isValidOutputPath, validateToolCommand, substitute helpers) as local copies instead of importing the real implementations.
+- Files: `src/index.test.ts:8`, `src/index.test.ts:193`, `src/index.test.ts:3`, `src/template.test.ts:183`, `src/template.test.ts:222`
+- Impact: Logic drift risk between source security checks and tests; changes to patterns (e.g. safe chars) require dual edits; violates "test behavior" guideline in AGENTS.md.
+- Fix approach: Extract pure validators to e.g. src/validators.ts (or export from modules), import in tests and source; remove copies.
 
-**Shell Execution with `shell: true`:**
-- Issue: `spawnSync` in `src/index.ts:111` uses `shell: true` for tool launching, adding an unnecessary shell parsing layer
-- Files: `src/index.ts` (lines 109–115)
-- Impact: Validation regex must be comprehensive enough to cover shell metacharacters
-- Fix approach: Where possible, use array-based spawn without `shell: true`; reserve `shell: true` only for template commands that require it
+**[Outdated and incomplete architecture documentation]:**
+- Issue: AGENTS.md architecture section lists only 10 src files and is missing later additions (cli/diff.ts, errors.ts, git-diff.ts, prompts.ts); historical docs use legacy names "ai-router"/"ai-switcher" and outdated config paths ~/.config/ai-router and ~/.ccs/config.json (now uses `ccs api list`).
+- Files: `AGENTS.md:107`, `AGENTS.md:118`, `tasks/prd-ai-cli-router.md:1`, `tasks/prd-ai-cli-router.md:101`, `scripts/ralph/progress.txt:8`, `scripts/ralph/progress.txt:11`, `scripts/ralph/progress.txt:47`
+- Impact: Misleading for agents/humans; search hits on old names; incorrect mental model of modules.
+- Fix approach: Update AGENTS.md file list + diagram; add note or move legacy PRDs under tasks/archive/; sync names.
 
-**Prompt Escaping Fragility:**
-- Issue: Single-quote escaping (`prompt.replace(/'/g, "'\\''"`) in `src/index.ts:124` is correct but undocumented and untested
-- Files: `src/index.ts` (lines 117–134)
-- Impact: Breaks silently if escaping logic is modified; no unit test coverage
-- Fix approach: Add dedicated unit tests for prompt escaping edge cases
+**[Version.ts generation and git state issues]:**
+- Issue: src/version.ts is committed (with stale "0.7.4" while package.json is "0.7.5"); AGENTS.md claims it is .gitignore'd (but .gitignore does not list it); two generation paths (build.sh using node -p, CI inline echo).
+- Files: `src/version.ts:3`, `package.json:3`, `scripts/build.sh:3`, `.github/workflows/release.yml:54`, `AGENTS.md:118`, `.gitignore`
+- Impact: `ai --version` lies in git tree or after pkg bump without rebuild; CI/local inconsistency.
+- Fix approach: Add `src/version.ts` to .gitignore, ensure clean before commit, run build in CI consistently or generate at import time.
+
+**[Dual build/version paths and script duplication]:**
+- Issue: Local `bun run build` runs bash scripts/build.sh; release matrix generates version.ts then calls bun build directly (no script); justfile and package scripts are thin wrappers.
+- Files: `scripts/build.sh:1`, `.github/workflows/release.yml:62`, `package.json:13`, `justfile:8`
+- Impact: Changes to build must be duplicated or risk divergence; version gen fragile.
+- Fix approach: Make build script the single source (support --target), call it from CI after version write, or move logic to TS.
+
+**[Casts and Record<unknown> patterns for validation]:**
+- Issue: Heavy use of `as Record<string, unknown>` + property checks and `as` casts in config/detect (required by strict + no any, but still manual).
+- Files: `src/config.ts:94`, `src/config.ts:135`, `src/config.ts:187`, `src/detect.ts:127`, `src/detect.ts:164`
+- Impact: Runtime type errors possible if schema changes; boilerplate.
+- Fix approach: Consider zod or valibot for runtime validation (adds dep) or keep but add more exhaustive test cases.
 
 ## Known Bugs
 
-**Git Diff Silent Truncation:**
-- Symptoms: Very large diffs (>10MB) are silently truncated by `maxBuffer`
-- Files: `src/git-diff.ts:33`
-- Trigger: Repositories with large binary diffs or very large changesets
-- Workaround: None currently; user gets a partial diff without warning
+**[Windows tool detection completely broken]:**
+- Symptoms: `commandExists` (used by detectInstalledTools and gh check) unconditionally spawns `"which"`, which does not exist on Windows; tools present via PATH or in expected locations are never auto-detected (ccs/gh-copilot also affected).
+- Files: `src/detect.ts:166`, `src/detect.ts:161`, `src/detect.ts:260`, `src/detect.ts:271`, `src/detect.ts:174`
+- Trigger: Any run of `ai` (or direct) on Windows (or mingw without which); CI ubuntu masks it.
+- Workaround: Manually add tools to config.json; `ai ccs:...` etc won't appear.
 
-**Fuzzy Select Terminal State Leak:**
-- Symptoms: If an exception escapes the key-handler loop, raw mode and hidden cursor may not be restored
-- Files: `src/fuzzy-select.ts` (lines 102–286)
-- Trigger: Uncaught exception during interactive selection
-- Workaround: Restart the terminal session
+**[Committed stale VERSION and runtime version reporting]:**
+- Symptoms: Built-in version may be behind package.json after edits; running `bun run src/index.ts --version` reports the committed src/version.ts value.
+- Files: `src/version.ts:3`, `package.json:3`
+- Trigger: Edit package.json version or use source tree without rebuild.
+- Workaround: Always `bun run build` before testing version.
+
+**[Overly broad output path forbidden patterns (substring match)]:**
+- Symptoms: `isValidOutputPath` rejects any relative path containing substrings like "etc/", "home/", "usr/", ".git/" even deep inside safe dirs (e.g. "notes/home-review.md", "project/etc/config.md").
+- Files: `src/index.ts:46`, `src/index.ts:59`, `src/index.ts:52`, `src/index.test.ts:204` (tests expect the broad behavior)
+- Trigger: `--diff-output notes/home-foo.md` or similar.
+- Workaround: Use names without the substrings.
+
+**[Template build vs validate inconsistency on multiple $@]:**
+- Symptoms: `validateTemplate` (and thus loadConfig) rejects >1 $@ ; however `buildTemplateCommand` (used in template.test and some execution) silently replaces only the first, leaving subsequent $@ in output.
+- Files: `src/config.ts:155`, `src/template.ts:32`, `src/template.test.ts:307`
+- Trigger: (Prevented at config load, but direct calls or future bypasses hit it.)
+
+**[TUI ESC/ arrow distinction is timing/racy]:**
+- Symptoms: Bare ESC treated with setTimeout(..., 50) to let arrow seqs (ESC+[) arrive; can incorrectly treat arrows as cancel or require perceptible delay.
+- Files: `src/fuzzy-select.ts:235`, `src/fuzzy-select.ts:238`, `src/fuzzy-select.ts:35`
+- Trigger: Pressing arrows or ESC rapidly, high-latency terminal, or certain term emulators.
+
+**[Install script fragile unstructured parse of GitHub releases JSON]:**
+- Symptoms: `grep "browser_download_url.*${ARTIFACT}" | cut -d '"' -f4 | head -n1` on raw JSON text; will break on whitespace changes, field reordering, or GitHub response evolution.
+- Files: `install.sh:41`, `install.sh:42`
+- Trigger: New release or GitHub API tweak.
+- Workaround: Use the curl | sh at your own risk; prefer Homebrew or manual download.
+
+**[Non-stdin prompt launch always uses "sh" -c even for Windows artifacts]:**
+- Symptoms: `launchToolWithPrompt` (used by all --diff-*) constructs `sh -c "cmd 'escaped'"` or spawn "sh"; Windows builds of the launcher will fail or behave differently when using --diff-* or custom prompts.
+- Files: `src/index.ts:240`, `src/index.ts:278`, `src/index.ts:206`, `.github/workflows/release.yml:29`
+- Trigger: `ai --diff-staged` or `ai claude --diff-commit HEAD` on Windows.
+
+**[CCS profile parsing regex is table-format specific and brittle]:**
+- Symptoms: `parseCcsApiList` relies on unicode box chars and exact `[OK]` column alignment; changes in ccs "api list" output (widths, encoding, status text) silently drop profiles.
+- Files: `src/detect.ts:210`, `src/detect.ts:204`
+- Trigger: ccs update or non-UTF8 locale.
 
 ## Security Considerations
 
-**Command Injection Prevention:**
-- Risk: User-supplied arguments flow into shell execution
-- Files: `src/index.ts`, `src/cli/diff.ts`, `src/git-diff.ts`
-- Current mitigation: Regex allowlist for commands/args; blocklist for `&&`, `||`, `;`, `$(...)`, backticks, `sudo`, `rm -rf`, redirects; single-quote escaping for prompts
-- Recommendations: Add integration-level tests exercising common injection vectors; document why certain characters (e.g., `|` in prompts) are allowed
+**[Core reliance on regex allowlist + limited dangerous blacklist + shell:true]:**
+- Risk: Any bypass of `isSafeCommand` / `validateArguments` / `isValidGitRef` / `isValidOutputPath` results in arbitrary command execution via `spawnSync(..., {shell:true})`. Regexes are complex and have evolved (backticks partially allowed for prompts).
+- Files: `src/template.ts:22` (isSafeCommand + SAFE_COMMAND_PATTERN + DANGEROUS_PATTERNS), `src/index.ts:149`, `src/index.ts:184`, `src/index.ts:200`, `src/index.ts:90` (validateArguments), `src/cli/diff.ts:32`, `src/index.ts:186`
+- Current mitigation: Length caps (500/200), explicit blocks for && || ; $( `sudo rm -rf > / , config-time isSafe + single $@ checks, git ref no metachars, output path no .. / protected names.
+- Recommendations: Move to argument-array spawning (use the existing parseTemplateCommand more widely); maintain an explicit allowlist of base binaries; add runtime sandbox notes or seccomp where possible; property-based/fuzz tests on validators.
 
-**Git Reference Injection:**
-- Risk: The `ref` parameter in `--diff-commit <ref>` could inject git flags
-- Files: `src/cli/diff.ts:50–53`
-- Current mitigation: `ref.startsWith("-")` check rejects flag-style inputs
-- Recommendations: Tighten to a whitelist pattern (alphanumeric, `.`, `/`, `~`, `^`, `@`) for valid git refs
+**[Prompt injection surface in diff analysis and sh -c paths]:**
+- Risk: Git diff content (or --diff-prompt) is inserted into shell command string after only ' escaping; large or specially crafted diffs could affect shell parsing or be interpreted by the target AI tool in unexpected ways.
+- Files: `src/index.ts:237`, `src/index.ts:275`, `src/cli/diff.ts:154`, `src/prompt-escaping.test.ts:22`
+- Current mitigation: Single-quote wrapping + ' -> '\'' replace; git refs validated; diff comes from local git (trusted in context).
+- Recommendations: Prefer `promptUseStdin: true` for all prompt tools; pass prompt via stdin/input to spawn instead of command line; document the risk.
 
-**Upgrade Binary Replacement (TOCTOU):**
-- Risk: Window between checksum verification and binary replacement could be exploited
-- Files: `src/upgrade.ts` (binary replacement logic)
-- Current mitigation: Backup and restore on failure; checksum verified before write
-- Recommendations: Consider atomic rename instead of write-then-delete
+**[Upgrade path fetches + executes arbitrary binaries from GitHub with only sha256]:**
+- Risk: Compromised release, CDN, or MitM (despite https) leads to code execution on `ai upgrade`; checksum verification is best-effort and after full download to tmp.
+- Files: `src/upgrade.ts:87`, `src/upgrade.ts:118`, `src/upgrade.ts:127`, `install.sh:40`
+- Current mitigation: Checksum from separate asset, sha256 verify, backup + atomic rename, platform allowlist.
+- Recommendations: Add release signatures (cosign/minisign) verification if GitHub supports; use streaming download + verify before write; consider pinned release hashes in client.
+
+**[User config can introduce powerful templates; validated only for syntax not intent]:**
+- Risk: Templates with `ccs ... --permission-mode acceptEdits` or similar can perform destructive edits once launched; no sandbox around the child.
+- Files: `src/config.ts:12` (DEFAULT_TEMPLATES), `src/config.ts:149` (validate uses isSafeCommand), `README.md:326`
+- Current: Only syntactic safety.
+- Recommendations: Document prominently; consider a --dry or audit log of launched commands.
+
+**[Full stdin slurped with no size limit for template input]:**
+- Risk: `cat huge.bin | ai template` or huge piped diff can OOM or cause slow/DoS on the launcher itself before even reaching the child.
+- Files: `src/index.ts:98`, `src/index.ts:304`
+- Current: Try/catch around readFileSync(0).
+- Recommendations: Add size limit + early error (similar to git-diff 10MB cap).
 
 ## Performance Bottlenecks
 
-**Fuse.js Re-instantiation:**
-- Problem: A new `Fuse` instance is created on each query in both `fuzzy-select.ts` and `lookup.ts`
-- Files: `src/fuzzy-select.ts`, `src/lookup.ts`
-- Cause: Instance created inside the function rather than cached
-- Improvement path: Instantiate once when the item list is known; reuse across queries
+**[Per-keystroke full fuzzy re-search + re-render in TUI]:**
+- Problem: Every printable/backspace triggers new Fuse search over items + full clear+redraw of up to 10+ lines.
+- Files: `src/fuzzy-select.ts:269`, `src/fuzzy-select.ts:273`, `src/fuzzy-select.ts:265`
+- Cause: No debounce, no incremental matching, render always rebuilds ANSI strings and queries stdout.columns.
+- Improvement path: Debounce 30-50ms on input; since N is tiny (typically <30), simple string filter first then fuse only on demand; cache filtered.
 
-**CCS Profile Detection Regex:**
-- Problem: Complex regex with alternation runs per-line on `ccs api list` output
-- Files: `src/detect.ts` (CCS profile parsing)
-- Cause: Unoptimized parsing of table-formatted CLI output
-- Improvement path: Pre-compile regex; consider string splitting instead of regex for table parsing
+**[Detection spawns external processes on every single invocation]:**
+- Problem: `ai` (interactive or direct) always runs detectInstalledTools which does multiple `which`, and if ccs present also `ccs api list` + gh check (with 3s timeouts).
+- Files: `src/index.ts:307`, `src/detect.ts:255`, `src/detect.ts:166`, `src/detect.ts:221`, `src/detect.ts:179`
+- Cause: No in-process cache or persistent result.
+- Improvement path: Memoize within process; optional fs cache (~/.cache/ai-launcher/detected.json with mtime or ttl).
+
+**[Upgrade and install pull full binary (~50MB+) into memory before disk]:**
+- Files: `src/upgrade.ts:124` (arrayBuffer), `install.sh:55`
+- Cause: Simple fetch + write pattern.
+- Improvement path: Stream to temp file + verify on the fly where possible.
+
+**[Git diff loads entire output (capped 10MB) into string]:**
+- Files: `src/git-diff.ts:15`, `src/git-diff.ts:57`
+- Also full string passed into prompt template.
+- Improvement: Stream/chunk per file for analysis if needed.
 
 ## Fragile Areas
 
-**Interactive Terminal UI:**
-- Files: `src/fuzzy-select.ts` (lines 56–287)
-- Why fragile: Complex ANSI escape code generation, terminal width detection, line-wrapping math, raw-mode lifecycle management
-- Safe modification: Extract rendering into pure functions; test width/wrapping calculations independently
-- Test coverage: Only the `toSelectableItems` export helper is tested; the interactive rendering and key handlers have no unit tests
+**[Custom raw-mode terminal UI with manual ANSI + key parsing]:**
+- Files: `src/fuzzy-select.ts:85` (fuzzySelect), `src/fuzzy-select.ts:113` (setRawMode(true)), `src/fuzzy-select.ts:228` (handleKey), `src/fuzzy-select.ts:182` (clear), `src/fuzzy-select.ts:39` (getTerminalWidth, cached only), `src/fuzzy-select.ts:64` (CSI codes)
+- Why fragile: Assumes ANSI everywhere, specific key sequences, stdout.columns snapshot never refreshed, 50ms ESC heuristic, manual line counting for clear, no handling of paste, SIGWINCH, focus events, or non-UTF8; Windows Terminal vs others differ.
+- Safe modification: Never edit without running in multiple terminals + tmux; wrap key handling; add resize listener that forces re-render.
+- Test coverage: `src/fuzzy-select.test.ts:85` only checks exports and toSelectableItems; `promptForInput` declared but not exercised; zero coverage of render, navigation, filtering, cleanup.
 
-**Config Validation:**
-- Files: `src/config.ts` (lines 34–149)
-- Why fragile: Multiple validation functions with overlapping but not identical logic
-- Safe modification: Consolidate validation into a single pass; add tests for config merge/override behavior
-- Test coverage: Good for basic validation; missing edge cases around malformed JSON and permission errors
+**[Ad-hoc string parsers and validators instead of structured]:**
+- Files: `src/template.ts:41` (parseTemplateCommand quote state machine), `src/cli/diff.ts:32` (isValidGitRef), `src/detect.ts:204` (parseCcsApiList), `src/index.ts:31` (isValidOutputPath + normalize + many regex), `src/index.ts:177` (split(/\s+/) after sub)
+- Why fragile: Subtle escaping, \ vs /, unicode, quoting differences, future output changes from git/ccs.
+- Safe modification: Add exhaustive unit + property tests; consider a small parser lib or keep simple with heavy tests.
 
-**Lookup Priority Chain:**
-- Files: `src/lookup.ts` (lines 39–103)
-- Why fragile: Five-tier priority ordering (exact → alias → suffix → substring → fuzzy) with a magic-number threshold (`0.05`) for fuzzy match confidence
-- Safe modification: Extract priority tiers into an enum or named constants; document the threshold rationale
-- Test coverage: Well tested; ambiguity detection threshold is the main undocumented assumption
+**[Child process lifecycle and exit code handling]:**
+- Files: `src/index.ts:22` (handleChildProcessError), `src/index.ts:184` (spawn), `src/index.ts:189`, many `process.exit(child.status ?? ...)` throughout index and cli/diff.
+- Why fragile: Signals, windows codes, stdio inherit vs pipe, shell:true side effects, concurrent? (none).
+- Safe: Centralize a launcher helper with proper error mapping; test exit paths.
+
+**[Upgrade atomic replace + permission recovery logic]:**
+- Files: `src/upgrade.ts:181` (try rename backup, needsRestore flag, EACCES special case, multiple unlinks)
+- Why fragile: Partial failure can leave .backup files or remove the binary; race with other upgrades or the running process.
+- Safe: Use a dedicated updater lib or simpler "download to side, exec new to self-replace on next run".
+
+**[GitHub Actions release matrix + secret-dependent homebrew push]:**
+- Files: `.github/workflows/release.yml:14` (matrix), `.github/workflows/release.yml:167` (HOMEBREW_TAP_TOKEN), version workflow concurrency.
+- Fragile to token rotation, tag format, artifact download v8 vs upload v7 mismatch in same file.
 
 ## Scaling Limits
 
-**Git Diff Buffer:**
-- Current capacity: 10MB (`src/git-diff.ts:33` — `maxBuffer: 10 * 1024 * 1024`)
-- Limit: `spawnSync` returns truncated output above this limit with no error
-- Scaling path: Validate output size; warn user; or switch to streaming (`spawn` + chunk collection) for large repos
+**[TUI list size and visibility]:**
+- Current capacity: maxVisible=10 hardcoded; works for the ~15-25 tools+templates most users have.
+- Limit: `src/fuzzy-select.ts:102`; when >>20 items the scroll/selection and "N more" UX degrade; render cost linear.
+- Scaling path: Virtual scrolling or search-only (no list) mode; not needed for current use case.
 
-**Fuzzy Select Visible Items:**
-- Current capacity: 10 items visible at once (`src/fuzzy-select.ts`)
-- Limit: Works fine with scrolling for moderate lists; edge cases with very narrow terminals (<40 cols)
-- Scaling path: Scrolling is already implemented; narrow-terminal rendering needs hardening
+**[Diff size hard cap]:**
+- Current: 10MB maxBuffer + 8MB warn `src/git-diff.ts:15`
+- Limit: Large monorepo diffs, vendored code, or binary changes cause GitCommandError or truncated analysis.
+- Scaling path: Per-file chunking + multiple AI calls, or user-specified --diff-paths filter.
+
+**[Memory for full prompt/stdin/diff]:**
+- All content turned into JS strings and passed to child or written.
+- Limit: Multi-hundred MB diffs will OOM the launcher before the AI tool sees it.
+- Scaling path: Size guards + streaming where tools support.
+
+**[Single-user local FS config + no concurrency control]:**
+- Fine for CLI launcher.
 
 ## Dependencies at Risk
 
-**fuse.js (7.1.0):**
-- Risk: Low — actively maintained, widely used
-- Impact: Core feature; all fuzzy matching depends on it
-- Migration plan: Could implement simple trie/substring matching internally if needed
+**[fuse.js ^7.3.0]:**
+- Risk: Core to all fuzzy selection and some lookup; only runtime dep besides semver. If major breaks or unmaintained, interactive is dead.
+- Impact: `src/fuzzy-select.ts:92`, `src/lookup.ts:37` and lookup ambiguity scoring.
+- Migration plan: Lightweight substitute (e.g. simple prefix + localeCompare + optional tiny levenshtein) since item count is tiny; or pin + vendor if needed.
 
-**semver (7.6.0):**
-- Risk: Very low — stable, widely used
-- Impact: Only the upgrade feature
-- Migration plan: Version comparison is simple enough to rewrite with string splitting if needed
+**[semver ^7.7.4]:**
+- Risk: Only used for VERSION >= latestVersion in upgrade.
+- Impact: Low; standard and stable.
+- Migration plan: Simple string compare or remove (GitHub tags are v-prefixed semver anyway).
+
+**[Bun runtime + --compile only]:**
+- Risk: All execution (shebang, test, build) and the distributed artifacts are Bun-specific. No tested pure-Node path.
+- Files: `package.json:5`, `src/index.ts:1`, `.github/workflows/*.yml`
+- Migration plan: N/A for now; document as Bun-only tool.
+
+**[GitHub (releases API, raw downloads, homebrew tap) as single distribution channel]:**
+- Risk: Outage, rate limit, or compromise affects all install/upgrade paths (curl, brew, `ai upgrade`).
+- Impact: `src/upgrade.ts:9`, `install.sh:39`, HomebrewFormula, release workflow.
+- Migration plan: Mirror releases; support multiple registries later.
+
+**[Renovate + biome pinned but transitive]:**
+- Low risk; small dep tree visible in bun.lock.
 
 ## Missing Critical Features
 
-**Error Recovery in Interactive Mode:**
-- Problem: No cleanup guarantee if an error occurs during fuzzy selection (e.g., git diff fails after TUI is active)
-- Blocks: Graceful error handling in chained tool-selection + diff-analysis flows
+**[No built-in way to manage/edit config]:**
+- Problem: Adding tools/templates/aliases requires hand-editing JSON at `~/.config/ai-launcher/config.json`; no `ai add`, `ai config edit`, or guided flow.
+- Blocks: New users, non-technical users, quick alias creation from CLI.
+- Files: `src/config.ts:248`, README long manual examples.
 
-**Diff Command Integration Tests:**
-- Problem: `src/cli/diff.ts` (`executeDiffCommand`) has no test coverage; only the underlying `git-diff.ts` primitives are tested
-- Blocks: Confident refactoring of the diff analysis command flow
+**[Incomplete Windows support (detection + prompt launch + TUI):**
+- Problem: "which" hardcode, "sh" -c, raw mode ANSI expectations, documented limitations.
+- Blocks: Full cross-platform promise in README and marketing.
+- Files: `src/detect.ts:166`, `src/index.ts:240`, README:727
+
+**[No timeouts, cancellation, or progress for network operations in upgrade]:**
+- Problem: `fetch` calls can hang forever on bad network.
+- Blocks: Reliable `ai upgrade` in flaky environments.
+- Files: `src/upgrade.ts:87`, `src/upgrade.ts:118`
+
+**[No integration / end-to-end tests for launch flows]:**
+- (See Test Gaps)
+
+**[No observability / audit of launched commands (for security review)].**
 
 ## Test Coverage Gaps
 
-**Interactive Terminal UI:**
-- What's not tested: `fuzzySelect()` main function — key handlers, search filtering, scrolling, ANSI rendering
-- Files: `src/fuzzy-select.ts` (lines 83–287)
-- Risk: Core UX feature could regress silently
+**[Interactive TUI behavior (fuzzySelect full flow)]:**
+- What's not tested: setRawMode, data listener, handleKey for all keys, updateFilter + fuse, moveUp/Down + scroll, render + ANSI + compact, clear, ESC timeout, promptForInput full interaction, resize behavior.
+- Files: `src/fuzzy-select.ts:85`, `src/fuzzy-select.test.ts:85` (only `toSelectableItems` + typeof check)
+- Risk: Any change to keys, filtering, display, or terminal assumptions silently breaks the primary UX; hard to catch without manual testing.
 - Priority: High
 
-**Command Launching:**
-- What's not tested: `launchTool()` and `launchToolWithPrompt()` — argument splitting, shell escaping, prompt building
-- Files: `src/index.ts` (lines 67–134)
-- Risk: Security-relevant shell interaction logic
+**[Launch / execution paths (launchTool, launchToolWithPrompt, template expansion in context, stdin, output files, status codes)]:**
+- What's not tested: The actual spawnSync calls, shell construction, error paths, exit, full main() branches for direct/fuzzy/dash/diff/template+stdin cases, writeFileSync success/failure in diff output.
+- Files: `src/index.ts:148`, `src/index.ts:194`, `src/prompt-escaping.test.ts:4` (only the replace logic), `src/index.test.ts` (parses + isolated validators only)
+- Risk: Injection vectors, platform spawn differences, file write errors, exit code bugs, $@ substitution errors go unnoticed until prod use.
 - Priority: High
 
-**Diff Analysis Orchestration:**
-- What's not tested: `executeDiffCommand()` end-to-end — tool selection + prompt building + diff retrieval
-- Files: `src/cli/diff.ts` (lines 65–117)
-- Risk: New feature, interaction between components untested
+**[Upgrade end-to-end (findBinaryPath, fetch, checksum, rename/backup/restore, permission cases, platform paths)]:**
+- What's not tested: Network, fs/promises operations, error recovery paths, actual binary locations.
+- Files: `src/upgrade.ts:69`, `src/upgrade.test.ts:3` (only artifact name, checksum parse, platform checks)
+- Risk: `ai upgrade` can leave system in broken state (missing binary, stray .backup); undetected on CI.
+- Priority: High
+
+**[Detection (commandExists, ccs profile parse, gh copilot, merge) under varied conditions]:**
+- What's not tested: Windows (always), mocked spawns, parse failures, timeout, ccs output variants, dedup edge cases.
+- Files: `src/detect.ts:161`, `src/detect.test.ts:245` (calls real detectInstalledTools and asserts provenance)
+- Risk: Silent loss of auto-detected tools, wrong ccs: profiles, gh-copilot never appears.
 - Priority: Medium
 
-**Template Quoting Edge Cases:**
-- What's not tested: `parseTemplateCommand()` with nested or escaped quotes
-- Files: `src/template.ts`
-- Risk: Malformed templates could produce incorrect or unsafe commands
+**[Config I/O and load (migrateOldConfig, createDefault, bad JSON, validation error formatting)]:**
+- What's not tested: File system side effects, migration success/failure, JSON syntax error vs validation error UX.
+- Files: `src/config.ts:228`, `src/config.ts:243`, `src/config.ts:248`, `src/config.test.ts` (validateTemplate only)
+- Risk: First-run failures, corrupted user config, poor error messages.
 - Priority: Medium
 
-**Config Error Handling:**
-- What's not tested: Malformed JSON, missing directories, permission errors during config load/save
-- Files: `src/config.ts` (lines 173–188)
-- Risk: App crashes instead of graceful degradation
-- Priority: Low
+**[Git diff + executeDiffCommand integration (real git states, prompt build, launchToolWithPrompt call, output file write)]:**
+- What's not tested deeply: execute path, useStdin branches, outputFile dir checks + write, various error classes.
+- Files: `src/cli/diff.ts:106`, `src/cli/diff.test.ts` (mostly parseDiffArgs + isValidGitRef), `src/git-diff.test.ts` (real git, limited states)
+- Risk: --diff-* feature silently fails or writes wrong files.
+- Priority: Medium
+
+**[Platform-specific branches, large input handling, full main error paths, ambiguity candidates]:**
+- Priority: Low/Medium (some unit coverage exists but not cross-platform).
 
 ---
 
-*Concerns audit: 2026-01-31*
+*Concerns audit: 2026-06-04*

--- a/.planning/codebase/CONVENTIONS.md
+++ b/.planning/codebase/CONVENTIONS.md
@@ -1,97 +1,135 @@
 # Coding Conventions
 
-**Analysis Date:** 2026-01-31
+**Analysis Date:** 2026-06-04
 
 ## Naming Patterns
 
 **Files:**
-- kebab-case for multi-word modules: `fuzzy-select.ts`, `git-diff.ts`
-- Single lowercase word when short: `config.ts`, `detect.ts`, `types.ts`, `errors.ts`
-- Tests mirror source name: `config.test.ts`, `git-diff.test.ts`
-- Sub-commands in `cli/`: `cli/diff.ts`
+- Source files use kebab-case for multi-word (e.g. `fuzzy-select.ts`, `git-diff.ts`, `prompt-escaping.test.ts`) per `AGENTS.md:65`
+- Simple names camel or single: `config.ts`, `index.ts`, `detect.ts`, `lookup.ts`, `template.ts`
+- Co-located tests: `<module>.test.ts` (e.g. `src/config.test.ts`, `src/cli/diff.test.ts`)
+- Generated: `src/version.ts` (overwritten by `scripts/build.sh:4`)
+- Type definition file: `src/types.ts`
 
 **Functions:**
-- camelCase: `detectTools`, `findToolByName`, `buildDiffAnalysisPrompt`
-- Boolean-returning: `is`/`has` prefix: `isGitRepository`, `isSafeCommand`
-- Action-oriented: `ensureGitRepository`, `parseDiffArgs`, `executeDiffCommand`
+- camelCase: `detectInstalledTools`, `findToolByName`, `isSafeCommand`, `loadConfig`, `validateConfig` (see `src/detect.ts:255`, `src/lookup.ts:11`, `src/template.ts:22`, `src/config.ts:248`)
+- Explicit return types required for public/exported functions per `AGENTS.md:39` and `tsconfig.json:14` strict
+- Examples: `export function findToolByName(query: string | undefined, items: SelectableItem[]): LookupResult` `src/lookup.ts:11`
+- Internal helpers also typed: `function handleChildProcessError(child: SpawnSyncReturns<string | Buffer>): void` `src/index.ts:22`
 
 **Variables:**
-- camelCase: `diffFlagIndex`, `analysisPrompt`, `toolCommand`
-- Constants: UPPER_SNAKE_CASE: `SAFE_COMMAND_PATTERN`, `CONFIG_PATH`, `MAX_ARG_LENGTH`
+- camelCase for let/const: `query`, `selectedIndex`, `filteredItems`, `stdinContent`
+- UPPER_SNAKE_CASE for module constants: `CONFIG_PATH`, `CONFIG_DIR`, `SAFE_COMMAND_PATTERN`, `DANGEROUS_PATTERNS`, `EXIT_CODE_SUCCESS`, `KNOWN_TOOLS`, `MAX_DIFF_BUFFER_SIZE` (`src/config.ts:7`, `src/template.ts:7`, `src/index.ts:17`, `src/detect.ts:13`, `src/git-diff.ts:15`)
+- Boolean prefixes: `isSafe`, `hasValidName`, `isTemplate`, `useStdin`
 
 **Types:**
-- PascalCase interfaces: `Tool`, `Config`, `SelectableItem`, `DiffCommandOptions`
-- Result types follow `<Feature>Result` pattern: `LookupResult`, `SelectionResult`
+- PascalCase for interfaces and exported types: `Tool`, `Template`, `Config`, `SelectableItem`, `LookupResult`, `SelectionResult`, `GitDiffOptions`, `DiffCommandOptions` (`src/types.ts:3`, `src/lookup.ts:4`, `src/fuzzy-select.ts:4`, `src/git-diff.ts:9`)
+- Type aliases: `KnownToolName`, `SuggestedInstallTool`, `AuthType`, `ParsedCommand` (`src/detect.ts:103`, `src/types.ts:1`, `src/template.ts:1`)
+- Use `unknown` instead of `any` for dynamic (e.g. `validateTool(tool: unknown` `src/config.ts:91`), enforced by biome `biome.json:26` and `AGENTS.md:38`
 
 ## Code Style
 
 **Formatting:**
-- Biome (`@biomejs/biome` 2.3.11)
-- Line width: 100 characters
-- Indentation: 2 spaces
-- Quotes: double quotes
-- Semicolons: always
+- Tool: Biome (configured in `biome.json`, run via `bun run format`)
+- Key settings from `biome.json:16`:
+  - indentStyle: "space", indentWidth: 2
+  - lineWidth: 100
+  - lineEnding: "lf"
+- javascript.formatter `biome.json:44`:
+  - quoteStyle: "double"
+  - semicolons: "always"
+  - trailingCommas: "es5"
+  - arrowParentheses: "always"
+- Matches AGENTS.md:47-49 exactly
 
 **Linting:**
-- Biome
-- Key rules: `noExplicitAny` (error), `noUnusedVariables` (error), `useConst` (error), `noNonNullAssertion` (warn)
-- TypeScript strict: `noUncheckedIndexedAccess`, `noUnusedLocals`, `noUnusedParameters`, `verbatimModuleSyntax`
+- Tool: Biome (`bun run lint`, `biome check`)
+- Key rules from `biome.json:23` and `AGENTS.md:50`:
+  - suspicious.noExplicitAny: "error"
+  - correctness.noUnusedVariables: "error"
+  - style.useConst: "error"
+  - style.noNonNullAssertion: "warn"
+  - noConsole: "off" (allowed for CLI)
+- TSConfig enforces: "strict": true `tsconfig.json:14`, "noUnusedLocals": true, "noUnusedParameters": true, "noUncheckedIndexedAccess": true `tsconfig.json:17`, "noImplicitOverride": true
+- Development workflow requires `bun run typecheck && bun run check` before tests (`AGENTS.md:130`)
 
 ## Import Organization
 
 **Order:**
-1. Node.js built-ins with `node:` prefix: `import { spawnSync } from "node:child_process"`
-2. External packages: `import Fuse from "fuse.js"`
-3. Type-only imports (separate): `import type { Tool } from "./types"`
-4. Internal modules: `import { findToolByName } from "./lookup"`
+1. External libraries (e.g. `import Fuse from "fuse.js"`, `import { gte as semverGte } from "semver"`) - `src/fuzzy-select.ts:1`, `src/lookup.ts:1`, `src/upgrade.ts:6`
+2. Node built-ins with `node:` prefix (required): `import { spawnSync } from "node:child_process"`, `import { readFileSync } from "node:fs"` etc. `src/index.ts:3-6`, `src/config.ts:1-3`, `src/detect.ts:1`
+3. Type-only imports using `import type` (verbatimModuleSyntax): `import type { SpawnSyncReturns } from "node:child_process"` `src/index.ts:3`; `import type { Config, ConfigValidationError, Template } from "./types"` `src/config.ts:5`
+4. Internal relative modules: `./config`, `./detect`, `./fuzzy-select`, `./lookup`, `./template`, `./cli/diff` (no index barrel) `src/index.ts:7-15`
+- Grouped as described in `AGENTS.md:60`: external, types, internal
+- `node:` prefix mandated `AGENTS.md:58`
 
 **Path Aliases:**
-- `@/*` resolves to `src/*` (defined in `tsconfig.json`)
-- Relative imports used within `src/` in practice
+- `@/*` -> `src/*` configured in `tsconfig.json:23-25`
+- Used? Not heavily in current sources (direct relatives preferred for small codebase)
 
 ## Error Handling
 
 **Patterns:**
-- Custom error classes for domain errors (`src/errors.ts`): `GitDiffError` → `NotGitRepositoryError`, `InvalidGitRefError`, `NoChangesError`, `GitCommandError`
-- Result objects for non-exceptional failures: `{ success: true, item }` / `{ success: false, error: "..." }`
-- Guard clauses with `process.exit(1)` for unrecoverable CLI errors after `console.error`
-- Top-level `main().catch()` to catch unhandled rejections
+- Lookup/validation results use discriminated success pattern (not exceptions for expected cases): `export interface LookupResult { success: boolean; item?: SelectableItem; error?: string; candidates?: SelectableItem[]; }` then `return { success: false, error: "..." }` or `{ success: true, item }` `src/lookup.ts:4-77`, `src/config.ts:185` (validateConfig returns ConfigValidationError[])
+- Guard clauses at top of functions (per `AGENTS.md:69` example): `if (!query) return { success: false... }`; `if (!trimmed) return false;` `src/template.ts:24`; `if (!isSafeCommand(command)) { console.error... process.exit(1); }` `src/index.ts:149`
+- Custom error hierarchy for domain: `src/errors.ts:5` - `GitDiffError` base, `NotGitRepositoryError`, `InvalidGitRefError`, `NoChangesError`, `GitCommandError`, `FileOutputError` (all extend Error with .name set)
+- try/catch around I/O and external: `catch (error) { console.error( error instanceof Error ? error.message : error ) ... process.exit(1) }` `src/index.ts:402`, `src/upgrade.ts:225`, `src/config.ts:235`
+- Validation: collect errors array then throw or return; formatValidationErrors `src/config.ts:211`
+- CLI: process.exit with specific codes (EXIT_CODE_* constants `src/index.ts:17-20`), never unhandled in main path
+- Security: regex allowlists before exec/spawn (e.g. `validateArguments`, `isValidGitRef` `src/cli/diff.ts:32`), no denylists only
+- Stdin read wrapped: `try { ... } catch { return null; }` `src/index.ts:95`
 
 ## Logging
 
-**Framework:** `console` (no library)
+**Framework:** console (no logger lib; `console.log`, `console.error`, `console.warn`)
 
 **Patterns:**
-- `console.error` for errors and warnings (prefixed with emoji: `❌`, `⚠️`)
-- `console.log` for user-facing status and output
-- No debug/trace logging
+- User-facing output: `console.log(\`Running: ${...}\`)`, success `✅`, errors prefixed `❌` or `Error:`
+- Errors always to stderr via console.error
+- Debug-ish: only in upgrade/download progress, diff size warnings
+- Never console in production paths except intentional CLI UX
+- In tests: no suppression, rely on expect for behavior
 
 ## Comments
 
 **When to Comment:**
-- JSDoc on exported functions that have non-obvious parameters or throw behavior
-- `@throws` tags used on functions that throw typed errors (e.g., `getGitDiff`)
-- Block comment at top of `errors.ts` and `cli/diff.ts` for module-level intent
-- No inline comments on obvious logic
+- Explain non-obvious: buffer limits, why delay for ESC vs arrows `src/fuzzy-select.ts:236`, security rationale for backticks in DANGEROUS_PATTERNS `src/template.ts:10`
+- Generated file header only `src/version.ts:1`
+- Avoid over-commenting; code is communication per `AGENTS.md:32`
 
 **JSDoc/TSDoc:**
-- Used selectively on key exported functions; not on every function
-- Example: `/** Get git diff based on options @throws {InvalidGitRefError} ... */`
+- Used for public API surface especially error-throwing functions: `@throws {NotGitRepositoryError}` `src/git-diff.ts:75`, `@throws` lists in `src/git-diff.ts:19-24`
+- Module-level: `/** Prompt generation for AI analysis */` `src/prompts.ts:3`; `/** Curated subset... */` `src/detect.ts:105`
+- Class docs for custom errors `src/errors.ts:2`
+- No TSDoc on every internal; prefer descriptive names + small functions
 
 ## Function Design
 
-**Size:** Small, focused functions — typically 10-30 lines. Complex flows split into `parse` + `execute` pairs (e.g., `parseDiffArgs` / `executeDiffCommand`).
+**Size:**
+- Small and focused: most <30 LOC body; e.g. `isSafeCommand` `src/template.ts:22-29` is pure guard+regex; `parseDiffArgs` handles one concern
+- Core principles `AGENTS.md:31`: Small, Safe Steps; Separate Tidying from Behavior Changes
 
-**Parameters:** Plain objects for multi-option functions (`GitDiffOptions`, `DiffCommandOptions`); simple positional args for 1-3 params.
+**Parameters:**
+- Typed strictly, no `any`; use `unknown` for JSON input then cast+check inside validators
+- Defaults for optionals: `launchTool(command: string, extraArgs: string[] = [], ...)` `src/index.ts:148`
+- Destructuring in callers but functions take clear objects (e.g. `GitDiffOptions`)
 
-**Return Values:** Result objects (`LookupResult`, `SelectionResult`) for functions that can fail without throwing. `void` or `never` for functions that exit the process on failure.
+**Return Values:**
+- Explicit types always for exported
+- Result objects over throwing for lookup/validate: `LookupResult`
+- `never` for functions that always exit: `launchToolWithPrompt(...): never` `src/index.ts:194`
+- void for side-effect only like `ensureConfigDir(): void`
 
 ## Module Design
 
-**Exports:** Each module exports only what other modules need. No re-exports or barrel files.
+**Exports:**
+- Named exports only (no default except biome side)
+- Public API per file: config exports load/validate/getConfigPath/validateTemplate; lookup exports findToolByName + interface; etc.
+- Re-export not used; consumers import directly from module `src/index.ts:7-15`
 
-**Barrel Files:** Not used. Imports reference source modules directly.
+**Barrel Files:**
+- None. Architecture diagram in `AGENTS.md:107` lists flat src/ modules; imports are specific (e.g. `import { loadConfig } from "./config"`). Avoids coupling.
 
 ---
 
-*Convention analysis: 2026-01-31*
+*Convention analysis: 2026-06-04*

--- a/.planning/codebase/INTEGRATIONS.md
+++ b/.planning/codebase/INTEGRATIONS.md
@@ -1,26 +1,23 @@
 # External Integrations
 
-**Analysis Date:** 2026-01-31
+**Analysis Date:** 2026-06-04
 
 ## APIs & External Services
 
-**GitHub API (upgrade feature):**
-- Fetches latest release from `https://api.github.com/repos/jellydn/ai-cli-switcher/releases/latest`
-- Downloads platform-specific binaries with SHA256 checksum verification
-- SDK/Client: native `node:https` / `fetch`
-- Auth: None (public repo, unauthenticated API calls)
+**GitHub Releases API:**
+- GitHub - Fetches latest release metadata, lists assets, downloads platform binaries and checksums.txt for self-upgrade and distribution
+- SDK/Client: native `fetch` (no third-party package)
+- Auth: none (public unauthenticated endpoints)
 
-**AI CLI Tools (launched by this tool):**
-- Claude CLI (Anthropic) — `claude`
-- OpenCode CLI — `opencode`
-- Sourcegraph Amp CLI — `amp`
-- CCS (Claude Code Switch) — `ccs` with profile detection via `ccs api list`
+**Local AI CLI Tool Spawning (user-installed):**
+- Detected tools (claude, gemini, opencode, amp, grok, ccs, ollama, cursor/agent, gh copilot, etc.) - Launched via subprocess to provide the actual AI coding functionality; also `ccs api list` for profile discovery and `gh copilot --version`
+- SDK/Client: `node:child_process` spawnSync (see `src/detect.ts:166`, `src/detect.ts:221`, `src/index.ts:184`)
+- Auth: delegated to the individual tools (OAuth or api_key metadata only in `src/types.ts:8` `authType`)
 
-**Git (diff analysis feature):**
-- `git diff --cached` — staged changes
-- `git diff <ref>` — diff against a commit reference
-- `git rev-parse --git-dir` — repository detection
-- SDK/Client: `node:child_process.spawnSync`
+**Git (for diff analysis):**
+- Git - Invoked for `git diff --cached`, `git diff <ref>`, `git rev-parse --git-dir` to support `--diff-staged` / `--diff-commit` features
+- SDK/Client: `spawnSync("git", ...)` in `src/git-diff.ts:36` and `src/git-diff.ts:87`
+- Auth: none (local repo operations)
 
 ## Data Storage
 
@@ -28,9 +25,7 @@
 - None
 
 **File Storage:**
-- Local filesystem only
-- User config: `~/.config/ai-switcher/config.json`
-- Binary self-update writes to the executable's own path
+- Local filesystem only - User config `~/.config/ai-launcher/config.json` (`src/config.ts:7`), temp binary during upgrade `src/upgrade.ts:114` (in `tmpdir()`), output files for `--diff-output` (validated relative paths in `src/index.ts:32`)
 
 **Caching:**
 - None
@@ -38,7 +33,10 @@
 ## Authentication & Identity
 
 **Auth Provider:**
-- None — this tool launches other CLIs that handle their own auth
+- None (no auth provider integrated into the launcher itself)
+
+**Implementation:**
+- No authentication, tokens, or login flows in the app; `authType` is only descriptive metadata for auto-detected proxy profiles (`src/detect.ts:250` "oauth", `src/detect.ts:237` "api_key") passed through to spawned tools
 
 ## Monitoring & Observability
 
@@ -46,28 +44,24 @@
 - None
 
 **Logs:**
-- `console.error` for error output; `console.log` for status messages
-- No structured logging framework
+- Console-based (stdout/stderr) - Direct `console.log`, `console.error`, `console.warn` for messages, errors, progress; no structured logging, files, or external services (examples throughout `src/index.ts`, `src/upgrade.ts:90`)
 
 ## CI/CD & Deployment
 
 **Hosting:**
-- GitHub Releases (binary distribution)
-- Homebrew tap (`jellydn/homebrew-tap`) for macOS installs
+- GitHub Releases (binaries + checksums hosted at https://github.com/jellydn/ai-launcher/releases; referenced in `install.sh:39`, `HomebrewFormula/ai.rb:8`, `src/upgrade.ts:9`)
 
 **CI Pipeline:**
-- GitHub Actions (`.github/workflows/`)
-  - `ci.yml` — typecheck + biome check + tests on push/PR to `main`
-  - `release.yml` — version bump → multi-platform build matrix → GitHub release → Homebrew tap update
-- Secrets required: `HOMEBREW_TAP_TOKEN`
+- GitHub Actions - Workflows: `.github/workflows/ci.yml` (checkout@v6, setup-bun, typecheck/check/test), `.github/workflows/release.yml` (multi-arch bun build, upload-artifact@v7, softprops/action-gh-release@v3, checksums, homebrew tap update), `.github/workflows/version.yml` (bumpp auto), `.github/workflows/sync-readme.yml`
 
 ## Environment Configuration
 
 **Required env vars:**
-- None at runtime
+- None for normal operation or interactive use
+- Optional path discovery only (in upgrade): `HOME`, `LOCALAPPDATA` (`src/upgrade.ts:39`, `src/upgrade.ts:42`)
 
 **Secrets location:**
-- GitHub Actions repository secrets (`HOMEBREW_TAP_TOKEN`)
+- None (application stores no secrets, tokens, or credentials; config is plain JSON without sensitive data)
 
 ## Webhooks & Callbacks
 
@@ -79,4 +73,4 @@
 
 ---
 
-*Integration audit: 2026-01-31*
+*Integration audit: 2026-06-04*

--- a/.planning/codebase/STACK.md
+++ b/.planning/codebase/STACK.md
@@ -1,69 +1,63 @@
 # Technology Stack
 
-**Analysis Date:** 2026-01-31
+**Analysis Date:** 2026-06-04
 
 ## Languages
 
 **Primary:**
-- TypeScript 5 (strict mode) - All source and test code in `src/`
+- TypeScript (strict, ESNext target) - Core application logic, CLI entrypoint, all modules in `src/*.ts` (e.g. `src/index.ts:1`, `src/detect.ts`, `src/config.ts:1`); types in `src/types.ts`; path alias `@/*` in `tsconfig.json:24`
+
+**Secondary:**
+- Shell (Bash, POSIX sh) - Build, install, and hook scripts: `scripts/build.sh:1` (generates `src/version.ts`), `install.sh:1`, `scripts/setup-hooks.sh`, `justfile:1`, `scripts/sync-readme.sh`, `scripts/pre-commit`
 
 ## Runtime
 
 **Environment:**
-- Bun (latest) - Runtime, test runner, and build compiler
+- Bun (runtime + bundler) - Shebang `src/index.ts:1` (`#!/usr/bin/env bun`), `package.json:12` (`"dev": "bun run src/index.ts"`), `package.json:22` ci script, `@types/bun` in devDeps `package.json:28`, CI setup ` .github/workflows/ci.yml:15` (oven-sh/setup-bun@v2 with latest)
 
 **Package Manager:**
-- Bun
-- Lockfile: present (`bun.lock`)
+- Bun - Primary; lockfile: present (`bun.lock` at repo root, lockfileVersion 1)
+- No npm/yarn/pnpm lockfiles
 
 ## Frameworks
 
 **Core:**
-- None — pure Node.js/Bun built-in modules (`node:child_process`, `node:fs`, `node:path`, `node:os`, `node:crypto`)
+- None (lightweight pure TypeScript CLI; relies on Node.js built-ins under Bun + minimal deps)
 
 **Testing:**
-- Bun native test framework (`bun:test`) — `describe`, `test`, `expect`
+- Bun test (`bun:test`) - `import { describe, test, expect } from "bun:test"` in all `*.test.ts` (e.g. `src/config.test.ts:1`, `src/detect.test.ts:1`, `src/index.test.ts`, `src/fuzzy-select.test.ts`, `src/lookup.test.ts`, `src/upgrade.test.ts`, `src/template.test.ts`, `src/git-diff.test.ts`, `src/cli/diff.test.ts`, `src/prompt-escaping.test.ts`); per `AGENTS.md:123`
 
 **Build/Dev:**
-- Bun compiler (`bun build --compile`) — produces standalone executables
-- Biome 2.3.11 — linting and formatting
-- TypeScript 5 — strict type checking (`tsc --noEmit`)
+- Biome 2.4.16 - Linting + formatting: `biome.json:1` (schema 2.4.10, lineWidth 100, indent 2, double quotes, semicolons always, noExplicitAny error, useConst error), `package.json:16-21` (lint, format, check scripts), overrides for `src/version.ts`
+- TypeScript ^6.0.3 - Strict type checking: `tsconfig.json:14` ("strict": true, "noUncheckedIndexedAccess": true, "noUnusedLocals": true, "verbatimModuleSyntax": true, "noEmit": true, "module": "Preserve"), `package.json:14` ("typecheck": "tsc --noEmit")
+- bun build --compile - Standalone executable: `scripts/build.sh:9` (`bun build src/index.ts --compile --outfile dist/ai`), also in release `.github/workflows/release.yml:63`
 
 ## Key Dependencies
 
 **Critical:**
-- `fuse.js` 7.1.0 — Fuzzy search powering the interactive tool selector
-- `semver` 7.6.0 — Version comparison for the upgrade feature
+- fuse.js ^7.3.0 - Fuzzy search matching for interactive TUI and name lookup: `src/fuzzy-select.ts:1` (`import Fuse from "fuse.js"`), config `new Fuse(items, { keys: ["name", "description", "aliases"], threshold: 0.4 })`, also `src/lookup.ts:1` and `src/lookup.ts:37`
+- semver ^7.7.4 - Semantic version comparison for upgrade check: `src/upgrade.ts:6` (`import { gte as semverGte } from "semver"`), `src/upgrade.ts:97` (`semverGte(VERSION, latestVersion)`)
 
-**Dev:**
-- `@biomejs/biome` 2.3.11 — Lint + format (replaces ESLint + Prettier)
-- `typescript` 5.x — Type checking only (no emit; Bun handles transpilation)
+**Infrastructure:**
+- Node.js built-ins (via Bun) - `node:child_process` (spawnSync/execSync for tool detection/launch/git/diff/which/ccs/gh): `src/index.ts:4`, `src/detect.ts:1`, `src/git-diff.ts:1`, `src/upgrade.ts:1`; `node:fs` / `node:fs/promises`, `node:path`, `node:os`, `node:crypto` (for upgrade temp files, checksums, paths): `src/config.ts:1`, `src/index.ts:5`, `src/upgrade.ts:3-5`
 
 ## Configuration
 
 **Environment:**
-- No `.env` files; no runtime environment variables required
-- User config stored at `~/.config/ai-switcher/config.json`
+- File-based user config (no env vars required for core use): `~/.config/ai-launcher/config.json` (`src/config.ts:7` `CONFIG_DIR = join(homedir(), ".config", "ai-launcher")`, `src/config.ts:8` `CONFIG_PATH`), auto-creates defaults on first run `src/config.ts:252-254`; old migration from `~/.config/ai-switcher`
+- Validation enforced at load: `src/config.ts:260` (validateConfig), safe patterns and $@ limit in `src/template.ts:7` and `src/config.ts:149`
 
 **Build:**
-- `tsconfig.json` — strict mode, path alias `@/*` → `src/*`, `verbatimModuleSyntax`
-- `biome.json` — 100-char line width, double quotes, 2-space indent
-- `package.json` scripts: `dev`, `build`, `typecheck`, `lint`, `check`, `ci`, `test`
-- `scripts/build.sh` — generates `src/version.ts` from `package.json` version, then compiles
+- `scripts/build.sh` (version injection + compile), `tsconfig.json`, `biome.json`, `package.json` scripts, `.github/workflows/release.yml:53` (version.ts gen in CI), `renovate.json`
 
 ## Platform Requirements
 
 **Development:**
-- Bun installed (`bun install`)
-- Git (for diff analysis feature)
+- Bun runtime (install via https://bun.sh), `bun install`, `bun run dev` / `bun run typecheck` / `bun run check` / `bun test` per `AGENTS.md:129-134`, `README.md:659`; macOS/Linux/Windows supported for dev with TTY for interactive
 
 **Production:**
-- Standalone binary; no runtime dependencies
-- Multi-platform targets built via GitHub Actions:
-  - `bun-linux-x64`, `bun-linux-arm64`
-  - `bun-darwin-x64`, `bun-darwin-arm64`
-  - `bun-windows-x64`
+- Standalone native executable `dist/ai` (or `ai.exe` on win) produced by `bun build --compile --target=...` for darwin-{x64,arm64}, linux-{x64,arm64}, windows-x64; distributed via GitHub Releases ` .github/workflows/release.yml:14` matrix, Homebrew `HomebrewFormula/ai.rb`, one-line curl `install.sh:37`; runs without Bun installed
 
 ---
 
-*Stack analysis: 2026-01-31*
+*Stack analysis: 2026-06-04*

--- a/.planning/codebase/STRUCTURE.md
+++ b/.planning/codebase/STRUCTURE.md
@@ -1,137 +1,268 @@
 # Codebase Structure
 
-**Analysis Date:** 2026-01-31
+**Analysis Date:** 2026-06-04
 
 ## Directory Layout
 
 ```
-ai-cli-switcher/
-├── src/                    # All TypeScript source and tests
-│   ├── cli/                # CLI sub-command handlers
-│   │   └── diff.ts         # --diff-staged / --diff-commit command
-│   ├── index.ts            # Entry point
-│   ├── types.ts            # Shared type definitions
-│   ├── config.ts           # Config load/save/validate
-│   ├── detect.ts           # Auto-detect installed AI CLIs
-│   ├── lookup.ts           # Tool lookup by name/alias/fuzzy
-│   ├── fuzzy-select.ts     # Interactive TUI with fuzzy search
-│   ├── template.ts         # Template command validation & execution
-│   ├── git-diff.ts         # Git diff extraction
-│   ├── prompts.ts          # AI analysis prompt generation
-│   ├── errors.ts           # Custom error class hierarchy
-│   ├── upgrade.ts          # Self-upgrade from GitHub releases
-│   ├── logo.ts             # ASCII art and ANSI colors
-│   ├── version.ts          # Generated at build time (gitignored)
-│   ├── *.test.ts           # Co-located unit tests (7 files)
-├── scripts/                # Build and setup scripts
-│   ├── build.sh            # Generate version.ts + compile binary
-│   ├── pre-commit          # Pre-commit hook
-│   ├── setup-hooks.sh      # Install git hooks
-│   └── ralph/              # Ralph autonomous agent config
-├── tasks/                  # PRD documents
-├── dist/                   # Build output (gitignored)
-├── .github/workflows/      # CI and release workflows
-├── HomebrewFormula/        # Homebrew formula for macOS
-├── .planning/              # Codebase documentation (this dir)
-├── package.json
-├── tsconfig.json
-├── biome.json
+ai-launcher/
+├── .changeset/                  # Changeset files for version bumps (e.g. add-freebuff-tool.md)
+├── .claude/                     # Claude-specific config/hooks (see .claude/hooks/)
+├── .github/                     # GitHub configuration
+│   └── workflows/               # CI/release automation
+│       ├── ci.yml
+│       ├── release.yml
+│       ├── sync-readme.yml
+│       └── version.yml
+├── .planning/                   # Planning artifacts (dot-dir)
+│   └── codebase/                # Codemap outputs (ARCHITECTURE.md, STRUCTURE.md, others)
+├── dist/                        # Build output (standalone executable; generated)
+│   └── ai
+├── docs/                        # GitHub Pages / docs site
+│   ├── _README.md               # Synced copy of README.md
+│   ├── CNAME
+│   ├── index.html
+│   ├── logo-icon.svg
+│   ├── logo.svg
+│   └── README.md
+├── HomebrewFormula/             # Homebrew tap formula
+│   └── ai.rb
+├── node_modules/                # Installed deps (bun + dev)
+├── scripts/                     # Dev / build / hook scripts
+│   ├── build.sh                 # Generates version.ts + bun --compile
+│   ├── pre-commit               # Biome check on staged (used by setup)
+│   ├── ralph/                   # Internal ralph automation (prd, prompt, progress)
+│   ├── setup-hooks.sh           # Installs git hooks
+│   └── sync-readme.sh
+├── src/                         # All application TypeScript source (strict, path alias @/*)
+│   ├── cli/                     # CLI subcommand modules
+│   │   ├── diff.test.ts
+│   │   └── diff.ts
+│   ├── config.test.ts
+│   ├── config.ts
+│   ├── detect.test.ts
+│   ├── detect.ts
+│   ├── errors.ts
+│   ├── fuzzy-select.test.ts
+│   ├── fuzzy-select.ts
+│   ├── git-diff.test.ts
+│   ├── git-diff.ts
+│   ├── index.test.ts
+│   ├── index.ts
+│   ├── logo.ts
+│   ├── lookup.test.ts
+│   ├── lookup.ts
+│   ├── prompt-escaping.test.ts
+│   ├── prompts.ts
+│   ├── template.test.ts
+│   ├── template.ts
+│   ├── types.ts
+│   ├── upgrade.test.ts
+│   ├── upgrade.ts
+│   └── version.ts               # Generated at build time (see biome override + .gitignore intent)
+├── tasks/                       # Historical PRD / task docs
+│   ├── prd-ai-cli-router.md
+│   └── prd-ci-cd-release.md
+├── AGENTS.md                    # Agent guidelines (required reading)
+├── biome.json                   # Formatter/linter config (2-space, 100-col, double quotes, strict rules)
 ├── bun.lock
-├── CLAUDE.md               # → delegates to AGENTS.md
-├── AGENTS.md               # Agent guidelines for this project
-└── README.md
+├── CLAUDE.md                    # Points to AGENTS.md
+├── example-config.json          # Example user config with tools + templates
+├── install.sh                   # One-line curl installer (POSIX)
+├── justfile                     # just dev/build/test shortcuts (mirrors package scripts)
+├── package.json                 # name:ai-launcher, bin:ai->dist/ai, scripts, deps (fuse.js, semver)
+├── prek.toml                    # prek git hook config (typecheck + biome)
+├── renovate.json
+├── tsconfig.json                # Strict TS, verbatimModuleSyntax, @/* -> src/*, rootDir src
+└── README.md                    # Full user docs + examples
 ```
 
 ## Directory Purposes
 
-**`src/`:**
-- Purpose: All application source code and tests
-- Contains: TypeScript modules (`.ts`) and co-located test files (`.test.ts`)
-- Key files: `index.ts` (entry), `types.ts` (shared types), `config.ts` (user config)
+**src/:**
+- Purpose: Entire application implementation. Single source of truth for logic.
+- Contains: All .ts modules + co-located Bun tests (* .test.ts). No subdirs except src/cli/
+- Key files: `src/index.ts` (entry), `src/types.ts`, `src/config.ts`, `src/detect.ts`, `src/lookup.ts`, `src/fuzzy-select.ts`, `src/template.ts`, `src/cli/diff.ts`, `src/git-diff.ts`, `src/upgrade.ts`
 
-**`src/cli/`:**
-- Purpose: CLI sub-command handlers extracted from `index.ts`
-- Contains: `diff.ts` — orchestrates the git diff analysis command
-- Key files: `diff.ts`
+**src/cli/:**
+- Purpose: Grouped modules for specific CLI sub-features (currently diff analysis).
+- Contains: diff.ts + diff.test.ts (parse/execute --diff-staged/--diff-commit etc)
+- Used by: imported only from `src/index.ts`
 
-**`scripts/`:**
-- Purpose: Developer tooling and automation
-- Contains: Build script, git hooks, Ralph agent config
-- Key files: `build.sh`, `pre-commit`, `setup-hooks.sh`
+**scripts/:**
+- Purpose: Build, install hooks, sync, and internal tooling.
+- Contains: build.sh (version gen + compile), setup-hooks.sh, sync-readme.sh, pre-commit, ralph/ subdir (ignored for core arch)
+- Key: `scripts/build.sh:4` (overwrites src/version.ts)
 
-**`.github/workflows/`:**
-- Purpose: CI/CD automation
-- Contains: `ci.yml` (lint + typecheck + test), `release.yml` (multi-platform build + GitHub release + Homebrew)
+**.github/workflows/:**
+- Purpose: Automated CI, releases, versioning, docs sync.
+- Contains: ci.yml (typecheck+check+test), release.yml (matrix compile + gh release + homebrew), version.yml (bumpp on main), sync-readme.yml
+- Triggers builds and produces dist artifacts for all platforms
 
-**`tasks/`:**
-- Purpose: Product requirements documents
-- Contains: `prd-ai-cli-router.md`, `prd-ci-cd-release.md`
+**docs/:**
+- Purpose: GitHub Pages site content + logo assets. README synced to _README.md on main pushes.
+- Contains: static html, svgs, CNAME, synced docs/_README.md
+
+**HomebrewFormula/:**
+- Purpose: Formula for `brew install jellydn/tap/ai`
+- Key file: `HomebrewFormula/ai.rb` (per-arch download + bin install as "ai")
+
+**tasks/:**
+- Purpose: Historical product requirement docs (not active source)
+
+**.changeset/:**
+- Purpose: Changeset entries driving releases (e.g. minor for new tool)
+
+**.planning/ (dot):**
+- Purpose: Scratch / planning outputs (including this codemap under codebase/)
+
+**dist/:**
+- Purpose: Compiled standalone binary output of `bun build --compile`
+- Generated: yes (by build or CI); present after local `bun run build`
 
 ## Key File Locations
 
 **Entry Points:**
-- `src/index.ts`: CLI binary entry point — argument parsing, tool launching
+- `src/index.ts`: Primary runtime entrypoint (shebang + main). Handles all arg flows, launches, orchestration. `package.json:5` ("module"), `package.json:12` (dev script)
+- `package.json:8`: Defines "bin" mapping "ai" -> "./dist/ai"
+- `scripts/build.sh`: Local build entry (also gens version)
+- `.github/workflows/release.yml:62`: CI build entry (direct bun build, version gen)
 
 **Configuration:**
-- `tsconfig.json`: TypeScript strict mode, path aliases
-- `biome.json`: Linter/formatter config
-- `package.json`: Scripts, dependencies, version
+- `src/config.ts`: Load/validate/create logic + DEFAULT_TEMPLATES + CONFIG_PATH (`~/.config/ai-launcher/config.json`)
+- `biome.json`: Linting/formatting rules + override to disable on src/version.ts
+- `tsconfig.json`: Strict compiler, paths, include src/**/*.ts
+- `example-config.json`: Sample with tools[] + templates[] (for docs)
+- `package.json`: version (0.7.5), scripts (ci, build, typecheck, check, test etc), deps
 
 **Core Logic:**
-- `src/config.ts`: User config (`~/.config/ai-switcher/config.json`) load/save
-- `src/detect.ts`: Detects installed AI CLIs via `which` and `ccs api list`
-- `src/lookup.ts`: Tool matching by name, alias, suffix, substring, fuzzy
-- `src/fuzzy-select.ts`: Interactive terminal UI powered by Fuse.js
-- `src/template.ts`: Template validation and `$@` substitution
-- `src/git-diff.ts`: Runs `git diff` commands
-- `src/cli/diff.ts`: Orchestrates the full diff-analysis flow
+- `src/detect.ts`: KNOWN_TOOLS list + detection/merge
+- `src/lookup.ts`: findToolByName + fuse heuristics + ambiguity
+- `src/fuzzy-select.ts`: full TUI (raw mode, render, keys, fuse filter)
+- `src/template.ts`: isSafeCommand, build/parse for $@
+- `src/cli/diff.ts`: parseDiffArgs + executeDiffCommand
+- `src/git-diff.ts`: getGitDiff + repo check (buffered)
+- `src/upgrade.ts`: upgrade flow + findBinaryPath
+- `src/prompts.ts`: buildDiffAnalysisPrompt
+- `src/errors.ts`: GitDiffError hierarchy
+- `src/logo.ts`: ascii + colors
+- `src/types.ts`: Tool, Template, Config, SelectableItem etc.
 
 **Testing:**
-- `src/*.test.ts`: 7 co-located test files covering config, detect, fuzzy-select, lookup, template, upgrade, git-diff
+- All tests co-located: `src/<module>.test.ts` (e.g. `src/lookup.test.ts` exhaustive on findToolByName cases, `src/template.test.ts` via validate + dynamic imports)
+- `src/index.test.ts`: extracted validation + parse logic tests
+- `bun test` or `bun test src/config.test.ts` (per AGENTS.md)
+
+**Build / Install / Release:**
+- `install.sh`: curl installer (artifact download + checksum + PATH hint)
+- `justfile`: task runner aliases for all package scripts
+- `HomebrewFormula/ai.rb`: brew formula
+- `.github/workflows/release.yml`: full release matrix + gh-release + homebrew update
+- `scripts/sync-readme.sh`, `scripts/setup-hooks.sh`
+
+**Other:**
+- `AGENTS.md`: Project coding rules (strict TS, biome, patterns, workflow: typecheck -> check -> test -> build)
+- `README.md`: User-facing (features, config schema, templates, security, platform notes)
+- `src/version.ts`: Overwritten at build (contains export const VERSION)
+- `renovate.json`, `prek.toml`, `bun.lock`
 
 ## Naming Conventions
 
 **Files:**
-- kebab-case: `fuzzy-select.ts`, `git-diff.ts`
-- Single-word when short: `config.ts`, `detect.ts`, `types.ts`
-- Tests co-located with `.<module>.test.ts` suffix
+- Kebab-case for modules per AGENTS.md: `fuzzy-select.ts`, `git-diff.ts`, `prompt-escaping.test.ts`
+- Co-located tests: `<name>.test.ts` (bun:test)
+- Config / data: kebab or descriptive (example-config.json, biome.json, tsconfig.json)
+- Scripts: descriptive-kebab.sh (build.sh, sync-readme.sh)
+- Generated: version.ts (explicitly marked in header comment)
 
 **Directories:**
-- lowercase, no separators: `src/`, `cli/`, `scripts/`
+- Lowercase: src/, src/cli/, scripts/, docs/, tasks/, .github/
+- Dot-dirs for tooling: .changeset/, .github/, .planning/, .claude/
+- Feature grouping only when >1 file (cli/ for diff subcommand)
+
+**Code (per AGENTS.md + observed):**
+- Interfaces / types: PascalCase (Tool, Config, SelectableItem, GitDiffError)
+- Functions / vars: camelCase (detectInstalledTools, loadConfig, findToolByName)
+- Constants: UPPER_SNAKE_CASE (CONFIG_PATH, KNOWN_TOOLS, SAFE_COMMAND_PATTERN, EXIT_CODE_*)
+- Booleans: is/has/should prefix (isSafeCommand, isTemplate, hasDiffCommand, promptUseStdin)
+- Type-only imports: `import type { ... } from "..."` (verbatimModuleSyntax)
+- Node builtins: always "node:child_process" etc.
+- Imports order: external (node:*, "fuse.js", "semver"), then types, then local ./
+- Path alias: `@/*` -> `src/*` (configured, used in some? but direct relative in sources)
 
 ## Where to Add New Code
 
-**New Feature:**
-- Primary code: `src/<feature-name>.ts`
-- Tests: `src/<feature-name>.test.ts` (co-located)
+**New Feature (e.g. new flag or mode):**
+- Primary code: `src/<new>.ts` (or extend `src/index.ts` / add under `src/cli/<feature>.ts` if subcommand)
+- Tests: `src/<new>.test.ts` (co-located; cover behavior, security cases, parse)
+- Update types if new shapes in `src/types.ts`
+- Wire in `src/index.ts` main dispatch
+- If needs special launch: extend launchTool* or use template safety
 
-**New CLI Sub-command:**
-- Handler: `src/cli/<command>.ts`
-- Wire-up: Add routing in `src/index.ts`
+**New Component/Module (e.g. new detector):**
+- Implementation: `src/<component>.ts`
+- Export public API, keep pure where possible
+- Add to relevant layer (e.g. detect logic -> detect.ts or new)
+- Update AGENTS.md architecture diagram if structural
 
-**New Component/Module:**
-- Implementation: `src/<module>.ts`
+**New CLI Subcommand:**
+- Add `src/cli/<sub>.ts` + test
+- Parse/execute in index or dedicated
+- Follow diff.ts pattern (context passing, error types)
 
-**Utilities:**
-- Shared helpers: Add to the most relevant existing module, or create `src/<name>.ts` if standalone
+**Utilities / Shared:**
+- Shared helpers: add to existing focused module (e.g. prompts.ts for prompt builders) or small pure file
+- Avoid new top-level unless clear boundary
+- Config changes: extend validate* + DEFAULT_ in `src/config.ts`
+
+**Build / Config / Docs changes:**
+- package.json / scripts / justfile for commands
+- .github/workflows/*.yml for CI/release
+- README.md + example-config.json for user docs
+- AGENTS.md for agent rules
+- Run full `bun run ci` + build before commit (per workflow)
+
+**Always:**
+- After edit: bun run typecheck && bun run check && bun test (AGENTS)
+- Prefer Bun; use tsx only if needed
+- Small safe steps; separate tidy from behavior
+- Cite paths in comments/docs when relevant
 
 ## Special Directories
 
-**`dist/`:**
-- Purpose: Compiled standalone binaries
-- Generated: Yes (by `bun build --compile`)
-- Committed: No (gitignored)
+**dist/:**
+- Purpose: Contains the standalone `ai` executable produced by bun --compile
+- Generated: Yes (never edit)
+- Committed: Appears in working tree after build (gitignore status not strictly excluding in this checkout, but intent is build artifact)
 
-**`src/version.ts`:**
-- Purpose: Exports `VERSION` string from `package.json`
-- Generated: Yes (by `scripts/build.sh` or CI)
-- Committed: No (gitignored)
+**src/version.ts:**
+- Purpose: Single source of runtime version string used in --version and upgrade checks
+- Generated: Yes (by scripts/build.sh or release CI writing from package.json or tag)
+- Committed: Source committed with placeholder (overwritten); biome linter/formatter disabled via override `biome.json:63`
 
-**`.planning/codebase/`:**
-- Purpose: Codebase documentation generated by the codemap skill
+**.planning/ (and .planning/codebase/):**
+- Purpose: Holds planning docs, codemap outputs (this STRUCTURE + ARCHITECTURE), other scratch
+- Generated: For analysis tasks
+- Committed: Yes (for this repo's process)
+
+**.changeset/:**
+- Purpose: Human + machine readable change descriptors consumed by release tooling
+- Generated: By changeset tooling on PRs
+- Committed: Yes
+
+**node_modules/ + bun.lock:**
+- Purpose: Dependency tree (bun)
 - Generated: Yes
-- Committed: Optional (not in `.gitignore`)
+- Committed: lock yes, node_modules typically not (but present here)
+
+**.github/ + scripts/ + justfile + prek.toml:**
+- Purpose: Automation, hooks, task runner (alternative to npm scripts)
+- Special: pre-commit hook runs biome; prek adds typecheck + biome on .ts; release does matrix cross-compile
+
+**docs/ + HomebrewFormula/:**
+- Purpose: Distribution metadata (pages, brew)
+- Synced/copied in workflows
 
 ---
 
-*Structure analysis: 2026-01-31*
+*Structure analysis: 2026-06-04*

--- a/.planning/codebase/TESTING.md
+++ b/.planning/codebase/TESTING.md
@@ -1,172 +1,186 @@
 # Testing Patterns
 
-**Analysis Date:** 2026-01-31
+**Analysis Date:** 2026-06-04
 
 ## Test Framework
 
 **Runner:**
-- Bun native test framework (`bun:test`)
-- Config: None (convention-based; Bun auto-discovers `*.test.ts`)
+- Bun's built-in test runner: `import { describe, test, expect } from "bun:test"`
+- Config: none (uses Bun defaults); `package.json:15` `"test": "bun test"`
+- Version tied to Bun runtime (devDep `@types/bun`)
 
 **Assertion Library:**
-- Bun's built-in `expect`
+- Bun's `expect` (chained matchers: `.toBe()`, `.toHaveLength()`, `.toContain()`, `.toThrow()`, `.toEqual()`, `.toBeGreaterThan()`, `.toMatch()` etc.)
 
 **Run Commands:**
 ```bash
-bun test                          # Run all tests
-bun test src/config.test.ts       # Run a specific test file
+bun test                          # Run all tests (per package.json:15, AGENTS.md:23)
+bun test src/config.test.ts       # Run specific test file (AGENTS.md:24)
+bun run ci                        # typecheck + check + test (package.json:22)
 ```
+- No built-in watch flag exposed in package scripts; `justfile:39` maps `test: bun test`
+- No coverage command (see Coverage section)
 
 ## Test File Organization
 
 **Location:**
-- Co-located with source: `src/<module>.test.ts` lives alongside `src/<module>.ts`
+- Co-located with source: `src/<module>.test.ts` alongside `src/<module>.ts`
+- Subdirectory support: `src/cli/diff.test.ts` tests `src/cli/diff.ts`
+- All 10 test files under src/ (confirmed via fd listing)
 
 **Naming:**
-- `<module>.test.ts` mirrors the source module name exactly
+- `<module>.test.ts` exactly (e.g. `config.test.ts`, `lookup.test.ts`, `prompt-escaping.test.ts`, `git-diff.test.ts`)
 
-**Test files (7 total):**
-- `src/config.test.ts`
-- `src/detect.test.ts`
-- `src/fuzzy-select.test.ts`
-- `src/lookup.test.ts`
-- `src/template.test.ts`
-- `src/upgrade.test.ts`
-- `src/git-diff.test.ts`
+**Structure:**
+```
+src/
+  config.ts
+  config.test.ts
+  detect.ts
+  detect.test.ts
+  ...
+  cli/
+    diff.ts
+    diff.test.ts
+```
 
 ## Test Structure
 
 **Suite Organization:**
 ```typescript
 import { describe, expect, test } from "bun:test";
-import { functionUnderTest } from "./module";
+import { findToolByName } from "./lookup";
+import type { SelectableItem } from "./types";
 
-describe("module name or feature area", () => {
-  describe("specific function or behavior", () => {
-    test("describes expected outcome", () => {
-      // Arrange → Act → Assert
-      const result = functionUnderTest(input);
-      expect(result).toBe(expected);
+const MOCK_ITEMS: SelectableItem[] = [ /* ... */ ];   // module-level fixture data
+
+describe("findToolByName", () => {
+  describe("exact name matching", () => {
+    test("finds tool by exact name", () => {
+      const result = findToolByName("claude", MOCK_ITEMS);
+      expect(result.success).toBe(true);
+      expect(result.item?.name).toBe("claude");
     });
+    // ...
   });
+  describe("fuzzy matching", () => { /* ... */ });
 });
 ```
+See full: `src/lookup.test.ts:57-267`, `src/config.test.ts:4-120`, `src/detect.test.ts:55`
 
 **Patterns:**
-- Nested `describe` blocks: outer = module/feature, inner = specific function or scenario
-- Test names describe the expected outcome (not the method called)
-- No shared `beforeEach`/`afterEach` — each test is self-contained
-- Inline helper functions when test logic needs shared setup (e.g., `substituteTemplateArgs` defined inside a `describe` block in `template.test.ts`)
+- Setup pattern: module-level consts (MOCK_ITEMS `src/lookup.test.ts:5`, CCS_API_LIST_OUTPUT `src/detect.test.ts:14`) or per-test inline objects. No beforeEach/afterEach used.
+- Teardown pattern: none (stateless pure units or live calls that are idempotent in test env).
+- Assertion pattern: direct `expect(result.success).toBe(true); expect(result.item?.name).toBe("...");` ; length checks `expect(errors).toHaveLength(0);` ; message contains `expect(errors[0]?.message).toContain("...")` or `.toMatch(/regex/)`
+- Nested describe for grouping concerns (exact/alias/suffix/fuzzy/ambiguous in lookup; "parseDiffArgs", "--diff-prompt flag" etc in cli/diff)
+- Some tests duplicate tiny logic under test (e.g. `validateToolCommand` helper inside `src/index.test.ts:3`) to isolate pure validation without full module side effects.
 
 ## Mocking
 
-**Framework:** Bun's built-in `jest.spyOn` / `jest.mock` (available via `bun:test`)
+**Framework:** None. (Confirmed: no `mock`, `spy`, `bun.mock`, `jest`, `vi.` anywhere in `*.test.ts`)
 
 **Patterns:**
 ```typescript
-// Spy on child_process for detection tests
-import { spawnSync } from "node:child_process";
-jest.spyOn(globalThis, "spawnSync"); // used in detect.test.ts
+// Direct calls to real implementation (accept side effects in env)
+const result = isGitRepository();   // src/git-diff.test.ts:9
+expect(result).toBe(true);          // test runs inside git repo
+
+// Dynamic import for module functions (in template.test.ts)
+const { isSafeCommand } = await import("./template");
+expect(isSafeCommand("rm -rf /")).toBe(false);
+
+// Inline test doubles for complex paths (no framework spies)
+function substituteTemplateArgs(command: string, args: string[]): string { /* copy logic */ }
 ```
+- `detectGhCopilot` test accepts live result or null `src/detect.test.ts:280`
+- No stubbing of spawnSync/fs etc; tests that hit external (git, which) are tolerant.
 
 **What to Mock:**
-- External process calls (`spawnSync`) when testing detection logic
-- File system operations when testing config loading
+- (Guideline inferred): avoid; test real behavior where possible. Use for expensive/net I/O if added later.
 
 **What NOT to Mock:**
-- Internal module functions — tests import and call them directly
-- Fuse.js — tested through real fuzzy matching behavior
+- Core pure functions (lookup, validation, isSafeCommand, parse*) - test directly.
+- Error classes and result shapes.
+- Live env checks that are fast (git repo presence, commandExists in detect tests).
 
 ## Fixtures and Factories
 
 **Test Data:**
 ```typescript
-// Inline fixtures — tool objects constructed directly in tests
-const tools: Tool[] = [
-  { name: "claude", command: "claude", aliases: ["cl"] },
-  { name: "amp", command: "amp", aliases: [] },
-];
+const MOCK_ITEMS: SelectableItem[] = [
+  { name: "claude", command: "claude", description: "...", isTemplate: false, aliases: ["c"] },
+  { name: "commit-zen", ..., isTemplate: true, aliases: ["commit"] },
+  // ...
+];   // src/lookup.test.ts:5
 
-// Config fixtures for validation tests
-const validConfig: Config = {
-  tools: [...],
-  templates: [...],
-};
+const CCS_API_LIST_OUTPUT = `...table with | glm | ... [OK] ...`;  // src/detect.test.ts:14
+// Variants for ANSI, ASCII pipes, error cases
 ```
+- Hard-coded realistic data: tool lists, CCS output tables, git diff snippets `src/git-diff.test.ts:40`, prompts.
+- No shared fixtures/ dir; everything inline or module const in the .test.ts
+- For validation: plain object literals passed to validateConfig/validateTemplate `src/config.test.ts:6`
 
 **Location:**
-- Inline within test files — no shared fixture directory
-- Each test constructs its own minimal data
+- Inside the test file that needs it. Reused across nested describes in same file.
 
 ## Coverage
 
-**Requirements:** None enforced (no coverage threshold configured)
+**Requirements:** None enforced. No coverage threshold or reporting in `package.json`, `justfile`, `AGENTS.md`, or CI (`bun run ci` runs `bun test` only).
 
 **View Coverage:**
 ```bash
-bun test --coverage
+# Not configured; Bun supports experimental --coverage but not used here
+bun test --coverage   # would work in Bun but not part of project scripts
 ```
+- Tests focus on behavior confidence per `AGENTS.md:126`, not metric chasing.
 
 ## Test Types
 
 **Unit Tests:**
-- Primary testing strategy — each module tested in isolation
-- Pure functions tested directly (lookup matching, template substitution, config validation)
-- Error cases tested via `expect(...).toThrow(ErrorType)`
+- Majority: pure functions (findToolByName, isSafeCommand, validate*, parse*, toSelectableItems, buildDiffAnalysisPrompt)
+- Scope: one module's exported behavior + error paths. Test names describe intent ("rejects template with multiple $@ placeholders")
+- Approach: table-like via many small test() cases; cover happy, edge, invalid input, case-insens, ambiguity.
 
 **Integration Tests:**
-- Limited — `template.test.ts` uses dynamic `import()` to test the full exported API:
-  ```typescript
-  test("buildTemplateCommand function exists and works", async () => {
-    const { buildTemplateCommand } = await import("./template");
-    const result = buildTemplateCommand("amp -x 'Review: $@'", ["file.ts"]);
-    expect(result).toBe("amp -x 'Review: file.ts'");
-  });
-  ```
+- Light: e.g. `src/template.test.ts` combines validateConfig + lookup + command build; `src/index.test.ts` reimplements arg parsing/output validation to cover launch paths without spawning.
+- `detectInstalledTools` runs real `which`/spawns in env but asserts shape.
+- No separate integration dir; mixed in unit files.
 
 **E2E Tests:**
-- Not used
+- Not used. Manual via `bun run src/index.ts claude --version` recommended in `AGENTS.md:25` and README. No Playwright/Cypress or full process exec tests in suite.
 
 ## Common Patterns
 
 **Async Testing:**
 ```typescript
-test("dynamic import works", async () => {
-  const { validateTemplateCommand } = await import("./template");
-  expect(validateTemplateCommand("rm -rf /")).toBe(false);
+test("buildTemplateCommand function exists and works", async () => {
+  const { buildTemplateCommand } = await import("./template");
+  const result = buildTemplateCommand("amp -x 'Review: $@'", ["file.ts"]);
+  expect(result).toBe("amp -x 'Review: file.ts'");
 });
 ```
+- Used when testing functions that are sync but import is dynamic to avoid top-level side effects or for future async.
+- `fuzzySelect` and `promptForInput` are async (return Promise) but their TTY tests are minimal (`src/fuzzy-select.test.ts:85`) - full interactive not unit-tested here.
+- Main entry `src/index.ts:402` uses `main().catch(...)` pattern (tested indirectly via other modules).
 
 **Error Testing:**
 ```typescript
-// Typed error assertion
 test("throws NoChangesError when no staged changes", () => {
   expect(() => getGitDiff({ type: "staged" })).toThrow(NoChangesError);
 });
-
-// Generic error class assertion
 test("throws GitDiffError for invalid options", () => {
   expect(() => getGitDiff({ type: "commit" })).toThrow(GitDiffError);
 });
+// validation
+expect(errors.length).toBeGreaterThan(0);
+expect(errors[0]?.message).toContain("at most one $@ placeholder");
+expect(errors[0]?.message).toMatch(/unsafe (characters|command substitution)/);
 ```
-
-**Security Testing:**
-```typescript
-// Template security — reject dangerous patterns
-test("rejects shell operators and command substitution", async () => {
-  const { validateTemplateCommand } = await import("./template");
-  expect(validateTemplateCommand("amp && rm -rf /")).toBe(false);
-  expect(validateTemplateCommand("amp $(whoami)")).toBe(false);
-  expect(validateTemplateCommand("sudo amp")).toBe(false);
-});
-
-// Accept safe special characters in prompts
-test("accepts special characters in prompts", async () => {
-  const { validateTemplateCommand } = await import("./template");
-  expect(validateTemplateCommand("claude -p 'Check <script> tags: $@'")).toBe(true);
-});
-```
+- Specific error class matching with `.toThrow(Constructor)`
+- For non-throwing validators: inspect returned error arrays by path/message
+- Also `expect(() => ...).not.toThrow()`
+- See `src/git-diff.test.ts:27`, `src/config.test.ts:35`, `src/cli/diff.test.ts:60`
 
 ---
 
-*Testing analysis: 2026-01-31*
+*Testing analysis: 2026-06-04*

--- a/src/detect.ts
+++ b/src/detect.ts
@@ -98,6 +98,12 @@ export const KNOWN_TOOLS = [
     description: "xAI Grok Build CLI",
     promptCommand: "grok --permission-mode plan -p",
   },
+  {
+    name: "mimo",
+    command: "mimo",
+    description: "Mi AI (mimocode) CLI",
+    promptCommand: "mimo run",
+  },
 ] as const satisfies readonly KnownToolDefinition[];
 
 export type KnownToolName = (typeof KNOWN_TOOLS)[number]["name"];

--- a/src/detect.ts
+++ b/src/detect.ts
@@ -117,6 +117,7 @@ export const SUGGESTED_INSTALL_TOOL_NAMES = [
   "codex",
   "grok",
   "ollama",
+  "mimo",
 ] as const satisfies readonly KnownToolName[];
 
 export type SuggestedInstallTool = {


### PR DESCRIPTION
## What

Add support for Mi AI (mimocode) CLI tool (`mimo`) to the known tools registry, enabling auto-detection and prompt-based launching.

## Why

`mimo` is a popular AI coding assistant that was missing from the launcher, requiring users to manually configure it via `config.json` even when it's installed on the system.

## How

- Added `mimo` entry to `KNOWN_TOOLS` in `src/detect.ts` with:
  - Command detection via `mimo` binary
  - `promptCommand`: `mimo run` (supports positional message args)

## Checklist

- [x] Tests added or updated (existing detect tests cover this path)
- [ ] Documentation updated
- [x] No breaking changes (or breaking changes documented above)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for detecting and executing the "mimo" (Mi AI CLI) tool.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->