### PR TITLE
docs: add mimo CLI to auto-detected tool list in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@
 ## ✨ Features
 
 - **🔍 Fuzzy Search**: Interactive terminal UI with real-time filtering and keyboard navigation
-- **🔧 Auto-Detection**: Automatically finds installed AI CLIs (claude, gemini, agy, opencode, amp, copilot, codex, kilo, pi, droid, ollama, cursor, ccs, cmd, freebuff, grok)
+- **🔧 Auto-Detection**: Automatically finds installed AI CLIs (claude, gemini, agy, opencode, amp, copilot, codex, kilo, pi, droid, ollama, cursor, ccs, cmd, freebuff, grok, mimo)
 - **⚡ Direct Invocation**: Skip the menu with `ai <toolname>` or fuzzy matching
 - **🏷️ Aliases**: Define short aliases for frequently used tools (e.g., `ai c` for claude)
 - **📋 Templates**: Create command shortcuts with `$@` argument/stdin placeholders
@@ -365,6 +365,7 @@ The following CLIs are auto-detected if installed and available in PATH:
 - `cmd` - Command Code CLI
 - `freebuff` - Freebuff, free ad-supported AI coding agent (Codebuff variant)
 - `grok` - xAI Grok Build CLI
+- `mimo` - Mi AI (mimocode) CLI
 
 **Precedence Rules:**
 


### PR DESCRIPTION
## What

Updated the README to list the new `mimo` (Mi AI / mimocode) CLI in the auto-detected tools.

## Why

The feat to add mimo CLI support (#61) was merged in v0.7.6, but the documentation wasn't updated to reflect this change. Users viewing the README or docs site would see an incomplete list of detected tools.

## How

- Added `mimo` to the comma-separated feature list in the ✨ Features section
- Added `mimo - Mi AI (mimocode) CLI` to the bullet-point auto-detection list

## Checklist

- [x] Documentation updated
- [x] No breaking changes