### PR TITLE
fix: address validated codebase concerns from CONCERNS.md

### DIFF
--- a/.changeset/fix-codebase-concerns.md
+++ b/.changeset/fix-codebase-concerns.md
@@ -1,0 +1,12 @@
+---
+"ai-launcher": patch
+---
+
+Fix validated codebase concerns
+
+- Detect tools on Windows using `where` instead of the missing `which`, and skip commands that shadow Windows built-ins (e.g. `cmd`).
+- Extract shared input validators to `src/validators.ts` so runtime checks and tests no longer drift.
+- Fix output-path validation: reject Windows absolute paths cross-platform, block nested hidden dirs (`.git`/`.config`) at any depth, and stop false-positiving on nested dirs that merely contain a protected name as a substring.
+- Cap piped stdin at 10MB, aborting before the payload is fully buffered.
+- Bound upgrade network calls with timeouts (including the binary body download) and a download size guard.
+- Memoize tool detection within a single invocation.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -111,11 +111,16 @@ src/
   detect.ts       - Auto-detect installed AI CLI tools
   fuzzy-select.ts - Interactive terminal UI with fuzzy search
   lookup.ts       - Tool lookup by name, alias, or fuzzy match
-  template.ts     - Template configuration
+  template.ts     - Template parsing and command safety checks
+  validators.ts   - Shared input validators (arguments, output paths)
   upgrade.ts      - Upgrade functionality
+  git-diff.ts     - Git diff retrieval for diff analysis
+  prompts.ts      - Prompt generation for AI diff analysis
+  errors.ts       - Custom error classes for git diff operations
+  cli/diff.ts     - --diff-* command parsing and execution
   types.ts        - Type definitions and interfaces
   logo.ts         - ASCII logo and colors
-  version.ts      - Generated at build time (.gitignore)
+  version.ts      - Generated at build time by scripts/build.sh / CI (committed, regenerated on build)
 ```
 
 ## Testing

--- a/src/detect.test.ts
+++ b/src/detect.test.ts
@@ -1,4 +1,4 @@
-import { describe, expect, test } from "bun:test";
+import { beforeEach, describe, expect, test } from "bun:test";
 import {
   detectCliProxyProfiles,
   detectGhCopilot,
@@ -8,8 +8,15 @@ import {
   KNOWN_TOOLS,
   type KnownToolDefinition,
   parseCcsApiList,
+  resetDetectionCache,
   SUGGESTED_INSTALL_TOOL_NAMES,
 } from "./detect";
+
+// Detection is memoized for the process lifetime; clear it before each test so
+// cases don't leak a cached result into one another.
+beforeEach(() => {
+  resetDetectionCache();
+});
 
 const CCS_API_LIST_OUTPUT = `CCS API Profiles
 

--- a/src/detect.ts
+++ b/src/detect.ts
@@ -183,7 +183,9 @@ function commandExists(command: string): boolean {
     return false;
   }
 
-  const result = spawnSync("which", [command], {
+  // "which" does not exist on Windows; use "where" there instead.
+  const lookupCommand = process.platform === "win32" ? "where" : "which";
+  const result = spawnSync(lookupCommand, [command], {
     encoding: "utf-8",
     stdio: ["pipe", "pipe", "pipe"],
   });
@@ -272,7 +274,21 @@ export function detectCliProxyProfiles(): Tool[] {
   }));
 }
 
+// Detection spawns several external processes (which/where, ccs, gh). The
+// result is stable for the lifetime of a single invocation, so memoize it to
+// avoid re-probing when the launcher calls detection more than once.
+let detectionCache: Tool[] | null = null;
+
+/** Clears the memoized detection result. Primarily useful in tests. */
+export function resetDetectionCache(): void {
+  detectionCache = null;
+}
+
 export function detectInstalledTools(): Tool[] {
+  if (detectionCache !== null) {
+    return detectionCache;
+  }
+
   const detected: Tool[] = [];
 
   for (const entry of KNOWN_TOOLS) {
@@ -304,6 +320,7 @@ export function detectInstalledTools(): Tool[] {
     detected.push(ghCopilot);
   }
 
+  detectionCache = detected;
   return detected;
 }
 

--- a/src/detect.ts
+++ b/src/detect.ts
@@ -284,15 +284,23 @@ export function resetDetectionCache(): void {
   detectionCache = null;
 }
 
+// Command names that collide with a built-in Windows executable and would
+// therefore be falsely "detected" by `where` on Windows (e.g. cmd -> cmd.exe).
+const WINDOWS_SHADOWED_COMMANDS = new Set(["cmd"]);
+
 export function detectInstalledTools(): Tool[] {
   if (detectionCache !== null) {
     return detectionCache;
   }
 
   const detected: Tool[] = [];
+  const isWindows = process.platform === "win32";
 
   for (const entry of KNOWN_TOOLS) {
     const tool: KnownToolDefinition = entry;
+    if (isWindows && WINDOWS_SHADOWED_COMMANDS.has(tool.command)) {
+      continue;
+    }
     if (commandExists(tool.command)) {
       detected.push({
         name: tool.name,

--- a/src/detect.ts
+++ b/src/detect.ts
@@ -290,7 +290,7 @@ const WINDOWS_SHADOWED_COMMANDS = new Set(["cmd"]);
 
 export function detectInstalledTools(): Tool[] {
   if (detectionCache !== null) {
-    return detectionCache;
+    return detectionCache.slice();
   }
 
   const detected: Tool[] = [];
@@ -329,7 +329,7 @@ export function detectInstalledTools(): Tool[] {
   }
 
   detectionCache = detected;
-  return detected;
+  return detected.slice();
 }
 
 export function mergeTools(configTools: Tool[], detectedTools: Tool[]): Tool[] {

--- a/src/index.test.ts
+++ b/src/index.test.ts
@@ -1,14 +1,6 @@
 import { describe, expect, test } from "bun:test";
-
-function validateToolCommand(command: string): boolean {
-  const safePattern = /^[a-zA-Z0-9._\s\-"':,!?/\\|$@]+$/;
-  return safePattern.test(command.trim()) && command.length > 0 && command.length <= 500;
-}
-
-function validateArguments(args: string[]): boolean {
-  const safePattern = /^[a-zA-Z0-9._\-"/\\@#=\s,.:()[\]{}]+$/;
-  return args.every((arg) => safePattern.test(arg) && arg.length <= 200);
-}
+import { isSafeCommand as validateToolCommand } from "./template";
+import { isValidOutputPath, validateArguments } from "./validators";
 
 describe("validateToolCommand", () => {
   test("accepts simple command", () => {
@@ -190,37 +182,6 @@ describe("Argument Parsing Logic", () => {
 });
 
 describe("Output Path Validation", () => {
-  function isValidOutputPath(path: string): boolean {
-    const normalized = path.replace(/\\/g, "/");
-
-    if (normalized.startsWith("/")) {
-      return false;
-    }
-
-    if (normalized.startsWith("..") || normalized.includes("/../")) {
-      return false;
-    }
-
-    const forbiddenPatterns = [
-      /^\./,
-      /\.git\//,
-      /\.config\//,
-      /etc\//,
-      /root\//,
-      /home\//,
-      /usr\//,
-      /var\//,
-    ];
-
-    for (const pattern of forbiddenPatterns) {
-      if (pattern.test(normalized)) {
-        return false;
-      }
-    }
-
-    return true;
-  }
-
   function validateOutputFile(filePath: string): string | null {
     if (!filePath || filePath.trim().length === 0) {
       return "Output file path cannot be empty";
@@ -241,6 +202,12 @@ describe("Output Path Validation", () => {
   test("accepts relative path with subdirectory", () => {
     expect(isValidOutputPath("results/analysis.md")).toBe(true);
     expect(isValidOutputPath("docs/output.txt")).toBe(true);
+  });
+
+  test("accepts nested dirs that merely contain a protected name as a substring", () => {
+    expect(isValidOutputPath("project/etc/config.md")).toBe(true);
+    expect(isValidOutputPath("notes/home-review.md")).toBe(true);
+    expect(isValidOutputPath("docs/usr-guide.md")).toBe(true);
   });
 
   test("rejects absolute paths", () => {

--- a/src/index.test.ts
+++ b/src/index.test.ts
@@ -216,6 +216,12 @@ describe("Output Path Validation", () => {
     expect(isValidOutputPath("/tmp/output.txt")).toBe(false);
   });
 
+  test("rejects Windows absolute paths regardless of host OS", () => {
+    expect(isValidOutputPath("C:/Windows/foo.md")).toBe(false);
+    expect(isValidOutputPath("C:\\Windows\\foo.md")).toBe(false);
+    expect(isValidOutputPath("D:\\data\\out.txt")).toBe(false);
+  });
+
   test("rejects paths starting with dot", () => {
     expect(isValidOutputPath(".hidden.md")).toBe(false);
     expect(isValidOutputPath("./secret.txt")).toBe(false);

--- a/src/index.test.ts
+++ b/src/index.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, test } from "bun:test";
 import { isSafeCommand as validateToolCommand } from "./template";
-import { isValidOutputPath, validateArguments } from "./validators";
+import { checkOutputPath, isValidOutputPath, validateArguments } from "./validators";
 
 describe("validateToolCommand", () => {
   test("accepts simple command", () => {
@@ -187,8 +187,9 @@ describe("Output Path Validation", () => {
       return "Output file path cannot be empty";
     }
 
-    if (!isValidOutputPath(filePath)) {
-      return "Invalid output file path";
+    const check = checkOutputPath(filePath);
+    if (!check.ok) {
+      return check.reason;
     }
 
     return null;
@@ -259,8 +260,20 @@ describe("Output Path Validation", () => {
     expect(validateOutputFile("   ")).toBe("Output file path cannot be empty");
   });
 
-  test("validateOutputFile returns error for invalid path", () => {
-    expect(validateOutputFile("/etc/passwd")).toBe("Invalid output file path");
-    expect(validateOutputFile("../file.md")).toBe("Invalid output file path");
+  test("validateOutputFile surfaces the specific rejection reason", () => {
+    expect(validateOutputFile("/etc/passwd")).toBe("absolute");
+    expect(validateOutputFile("C:/Windows/foo.md")).toBe("absolute");
+    expect(validateOutputFile("../file.md")).toBe("escape");
+    expect(validateOutputFile("sub/.git/config")).toBe("hidden");
+    expect(validateOutputFile("etc/passwd")).toBe("protected");
+  });
+
+  test("checkOutputPath reports a typed reason for each rejection class", () => {
+    expect(checkOutputPath("analysis.md")).toEqual({ ok: true });
+    expect(checkOutputPath("/etc/passwd")).toEqual({ ok: false, reason: "absolute" });
+    expect(checkOutputPath("C:\\Windows\\foo.md")).toEqual({ ok: false, reason: "absolute" });
+    expect(checkOutputPath("../escape.md")).toEqual({ ok: false, reason: "escape" });
+    expect(checkOutputPath("a/b/.ssh/id_rsa")).toEqual({ ok: false, reason: "hidden" });
+    expect(checkOutputPath("var/log/syslog")).toEqual({ ok: false, reason: "protected" });
   });
 });

--- a/src/index.test.ts
+++ b/src/index.test.ts
@@ -227,6 +227,12 @@ describe("Output Path Validation", () => {
     expect(isValidOutputPath("..%2F..%2Fetc%2Fpasswd")).toBe(false);
   });
 
+  test("rejects nested hidden directories such as .git or .config", () => {
+    expect(isValidOutputPath("sub/.git/hooks/pre-commit")).toBe(false);
+    expect(isValidOutputPath("project/.config/settings.json")).toBe(false);
+    expect(isValidOutputPath("a/b/.ssh/id_rsa")).toBe(false);
+  });
+
   test("rejects paths to protected directories", () => {
     expect(isValidOutputPath(".git/config")).toBe(false);
     expect(isValidOutputPath(".config/settings.json")).toBe(false);

--- a/src/index.ts
+++ b/src/index.ts
@@ -64,13 +64,27 @@ function readStdin(): string | null {
   const chunks: Buffer[] = [];
   let total = 0;
 
+  // If stdin is non-blocking and not ready, readSync throws EAGAIN. Back off
+  // briefly between retries (rather than busy-spinning a core) and give up
+  // after a bounded wait, treating it as "no stdin" like the old best-effort
+  // readFileSync behavior.
+  const EAGAIN_BACKOFF_MS = 5;
+  const MAX_EAGAIN_RETRIES = 2000; // ~10s of retries before giving up
+  const sleepSlot = new Int32Array(new SharedArrayBuffer(4));
+  let eagainRetries = 0;
+
   while (true) {
     let bytesRead: number;
     try {
       bytesRead = readSync(0, buffer, 0, CHUNK_SIZE, null);
+      eagainRetries = 0;
     } catch (error) {
       const code = (error as NodeJS.ErrnoException).code;
-      if (code === "EAGAIN") continue; // stdin not ready yet, retry
+      if (code === "EAGAIN") {
+        if (++eagainRetries > MAX_EAGAIN_RETRIES) return null;
+        Atomics.wait(sleepSlot, 0, 0, EAGAIN_BACKOFF_MS);
+        continue;
+      }
       if (code === "EOF") break; // Windows signals end-of-input this way
       return null;
     }

--- a/src/index.ts
+++ b/src/index.ts
@@ -12,7 +12,7 @@ import { getColoredLogo } from "./logo";
 import { findToolByName } from "./lookup";
 import { isSafeCommand } from "./template";
 import { upgrade } from "./upgrade";
-import { isValidOutputPath, validateArguments } from "./validators";
+import { type OutputPathRejection, checkOutputPath, validateArguments } from "./validators";
 import { VERSION } from "./version";
 
 const EXIT_CODE_SUCCESS = 0;
@@ -29,13 +29,21 @@ function handleChildProcessError(child: SpawnSyncReturns<string | Buffer>): void
   }
 }
 
+const OUTPUT_PATH_REASON_MESSAGES: Record<OutputPathRejection, string> = {
+  absolute: "Output file path must be relative, not absolute",
+  escape: "Output file path cannot escape the current directory",
+  hidden: "Output file path cannot point to a hidden file or directory",
+  protected: "Output file path points to a protected location",
+};
+
 function validateOutputFile(filePath: string): string | null {
   if (!filePath || filePath.trim().length === 0) {
     return "Output file path cannot be empty";
   }
 
-  if (!isValidOutputPath(filePath)) {
-    return "Invalid output file path";
+  const pathCheck = checkOutputPath(filePath);
+  if (!pathCheck.ok) {
+    return OUTPUT_PATH_REASON_MESSAGES[pathCheck.reason];
   }
 
   const resolvedPath = resolve(filePath);

--- a/src/index.ts
+++ b/src/index.ts
@@ -12,7 +12,7 @@ import { getColoredLogo } from "./logo";
 import { findToolByName } from "./lookup";
 import { isSafeCommand } from "./template";
 import { upgrade } from "./upgrade";
-import { type OutputPathRejection, checkOutputPath, validateArguments } from "./validators";
+import { checkOutputPath, type OutputPathRejection, validateArguments } from "./validators";
 import { VERSION } from "./version";
 
 const EXIT_CODE_SUCCESS = 0;

--- a/src/index.ts
+++ b/src/index.ts
@@ -2,7 +2,7 @@
 
 import type { SpawnSyncReturns } from "node:child_process";
 import { spawnSync } from "node:child_process";
-import { existsSync, readFileSync, writeFileSync } from "node:fs";
+import { existsSync, readSync, writeFileSync } from "node:fs";
 import { dirname, resolve } from "node:path";
 import { executeDiffCommand, parseDiffArgs } from "./cli/diff";
 import { loadConfig } from "./config";
@@ -54,20 +54,41 @@ function validateOutputFile(filePath: string): string | null {
 const MAX_STDIN_SIZE = 10 * 1024 * 1024;
 
 function readStdin(): string | null {
-  try {
-    const isInteractive = process.stdin.isTTY;
-    if (isInteractive) return null;
-    const content = readFileSync(0, "utf-8");
-    if (Buffer.byteLength(content, "utf-8") > MAX_STDIN_SIZE) {
+  const isInteractive = process.stdin.isTTY;
+  if (isInteractive) return null;
+
+  // Read fd 0 incrementally so an oversized pipe is aborted *before* the whole
+  // payload is buffered into memory, rather than after.
+  const CHUNK_SIZE = 64 * 1024;
+  const buffer = Buffer.alloc(CHUNK_SIZE);
+  const chunks: Buffer[] = [];
+  let total = 0;
+
+  while (true) {
+    let bytesRead: number;
+    try {
+      bytesRead = readSync(0, buffer, 0, CHUNK_SIZE, null);
+    } catch (error) {
+      const code = (error as NodeJS.ErrnoException).code;
+      if (code === "EAGAIN") continue; // stdin not ready yet, retry
+      if (code === "EOF") break; // Windows signals end-of-input this way
+      return null;
+    }
+
+    if (bytesRead === 0) break;
+
+    total += bytesRead;
+    if (total > MAX_STDIN_SIZE) {
       console.error(
         `Error: stdin input exceeds ${MAX_STDIN_SIZE / 1024 / 1024}MB limit and was rejected.`
       );
       process.exit(1);
     }
-    return content.trim();
-  } catch {
-    return null;
+
+    chunks.push(Buffer.from(buffer.subarray(0, bytesRead)));
   }
+
+  return Buffer.concat(chunks).toString("utf-8").trim();
 }
 
 function showVersion() {

--- a/src/index.ts
+++ b/src/index.ts
@@ -3,7 +3,7 @@
 import type { SpawnSyncReturns } from "node:child_process";
 import { spawnSync } from "node:child_process";
 import { existsSync, readFileSync, writeFileSync } from "node:fs";
-import { dirname, isAbsolute, normalize, resolve } from "node:path";
+import { dirname, resolve } from "node:path";
 import { executeDiffCommand, parseDiffArgs } from "./cli/diff";
 import { loadConfig } from "./config";
 import { detectInstalledTools, formatSuggestedInstallHints, mergeTools } from "./detect";
@@ -12,6 +12,7 @@ import { getColoredLogo } from "./logo";
 import { findToolByName } from "./lookup";
 import { isSafeCommand } from "./template";
 import { upgrade } from "./upgrade";
+import { isValidOutputPath, validateArguments } from "./validators";
 import { VERSION } from "./version";
 
 const EXIT_CODE_SUCCESS = 0;
@@ -26,44 +27,6 @@ function handleChildProcessError(child: SpawnSyncReturns<string | Buffer>): void
     );
     process.exit(EXIT_CODE_PROCESS_ERROR);
   }
-}
-
-function isValidOutputPath(filePath: string): boolean {
-  const normalized = normalize(filePath);
-
-  if (isAbsolute(normalized)) {
-    console.error("Error: Output file path must be relative, not absolute");
-    return false;
-  }
-
-  const isPathEscape =
-    normalized.startsWith("..") || normalized.includes("/../") || normalized.includes("\\..\\");
-  if (isPathEscape) {
-    console.error("Error: Output file path cannot escape current directory");
-    return false;
-  }
-
-  const forbiddenPatterns = [
-    /^\./,
-    /\.git\//,
-    /\.config\//,
-    /etc\//,
-    /root\//,
-    /home\//,
-    /usr\//,
-    /var\//,
-    /sys\//,
-    /proc\//,
-  ];
-
-  for (const pattern of forbiddenPatterns) {
-    if (pattern.test(normalized)) {
-      console.error("Error: Output file path points to a protected location");
-      return false;
-    }
-  }
-
-  return true;
 }
 
 function validateOutputFile(filePath: string): string | null {
@@ -86,16 +49,22 @@ function validateOutputFile(filePath: string): string | null {
   return null;
 }
 
-function validateArguments(args: string[]): boolean {
-  const safePattern = /^[a-zA-Z0-9._\-"/\\@#=\s,.:()[\]{}]+$/;
-  return args.every((arg) => safePattern.test(arg) && arg.length <= 200);
-}
+// Cap stdin so a huge pipe (e.g. `cat huge.bin | ai template`) cannot OOM the
+// launcher before it ever reaches the child process.
+const MAX_STDIN_SIZE = 10 * 1024 * 1024;
 
 function readStdin(): string | null {
   try {
     const isInteractive = process.stdin.isTTY;
     if (isInteractive) return null;
-    return readFileSync(0, "utf-8").trim();
+    const content = readFileSync(0, "utf-8");
+    if (Buffer.byteLength(content, "utf-8") > MAX_STDIN_SIZE) {
+      console.error(
+        `Error: stdin input exceeds ${MAX_STDIN_SIZE / 1024 / 1024}MB limit and was rejected.`
+      );
+      process.exit(1);
+    }
+    return content.trim();
   } catch {
     return null;
   }

--- a/src/upgrade.ts
+++ b/src/upgrade.ts
@@ -24,7 +24,14 @@ const binaryExt = isWindows ? ".exe" : "";
 // Network requests during upgrade should fail fast instead of hanging forever
 // on a flaky connection.
 const FETCH_TIMEOUT_MS = 30_000;
+// The binary download gets a larger wall-clock budget than metadata requests.
+const DOWNLOAD_TIMEOUT_MS = 5 * 60_000;
+// Guard against a malicious/misconfigured release trying to OOM the upgrader.
+const MAX_DOWNLOAD_SIZE = 200 * 1024 * 1024;
 
+// The AbortSignal is attached to the request, so it bounds the entire exchange
+// (headers *and* body). Reading the body (e.g. `arrayBuffer()`) aborts too if
+// the deadline elapses mid-download.
 async function fetchWithTimeout(url: string, timeoutMs = FETCH_TIMEOUT_MS): Promise<Response> {
   return fetch(url, { signal: AbortSignal.timeout(timeoutMs) });
 }
@@ -123,13 +130,27 @@ export async function upgrade() {
 
     console.log(`Downloading from: ${downloadUrl}`);
 
-    const binaryResponse = await fetchWithTimeout(downloadUrl);
+    const binaryResponse = await fetchWithTimeout(downloadUrl, DOWNLOAD_TIMEOUT_MS);
     if (!binaryResponse.ok) {
       console.error(`Failed to download binary: ${binaryResponse.statusText}`);
       process.exit(1);
     }
 
+    const declaredSize = Number(binaryResponse.headers.get("content-length"));
+    if (Number.isFinite(declaredSize) && declaredSize > MAX_DOWNLOAD_SIZE) {
+      console.error(
+        `❌ Refusing to download: reported size ${declaredSize} exceeds ${MAX_DOWNLOAD_SIZE / 1024 / 1024}MB limit`
+      );
+      process.exit(1);
+    }
+
     const binaryData = await binaryResponse.arrayBuffer();
+    if (binaryData.byteLength > MAX_DOWNLOAD_SIZE) {
+      console.error(
+        `❌ Downloaded binary exceeds ${MAX_DOWNLOAD_SIZE / 1024 / 1024}MB limit and was rejected`
+      );
+      process.exit(1);
+    }
     await writeFile(tempBinaryPath, Buffer.from(binaryData));
 
     const checksumAsset = release.assets.find((a) => a.name === "checksums.txt");

--- a/src/upgrade.ts
+++ b/src/upgrade.ts
@@ -21,6 +21,14 @@ interface GitHubRelease {
 const isWindows = process.platform === "win32";
 const binaryExt = isWindows ? ".exe" : "";
 
+// Network requests during upgrade should fail fast instead of hanging forever
+// on a flaky connection.
+const FETCH_TIMEOUT_MS = 30_000;
+
+async function fetchWithTimeout(url: string, timeoutMs = FETCH_TIMEOUT_MS): Promise<Response> {
+  return fetch(url, { signal: AbortSignal.timeout(timeoutMs) });
+}
+
 async function findBinaryPath(): Promise<string | null> {
   const binaryName = `ai${binaryExt}`;
 
@@ -84,7 +92,7 @@ export async function upgrade() {
   console.log(`Checking for updates...`);
 
   try {
-    const response = await fetch(GITHUB_RELEASES_URL);
+    const response = await fetchWithTimeout(GITHUB_RELEASES_URL);
 
     if (!response.ok) {
       console.error(`Failed to fetch release information: ${response.statusText}`);
@@ -115,7 +123,7 @@ export async function upgrade() {
 
     console.log(`Downloading from: ${downloadUrl}`);
 
-    const binaryResponse = await fetch(downloadUrl);
+    const binaryResponse = await fetchWithTimeout(downloadUrl);
     if (!binaryResponse.ok) {
       console.error(`Failed to download binary: ${binaryResponse.statusText}`);
       process.exit(1);
@@ -128,7 +136,7 @@ export async function upgrade() {
 
     if (checksumAsset) {
       console.log("Verifying checksum...");
-      const checksumResponse = await fetch(checksumAsset.browser_download_url);
+      const checksumResponse = await fetchWithTimeout(checksumAsset.browser_download_url);
       if (checksumResponse.ok) {
         const checksumText = await checksumResponse.text();
         const lines = checksumText.split("\n");

--- a/src/validators.ts
+++ b/src/validators.ts
@@ -9,11 +9,15 @@ export function validateArguments(args: string[]): boolean {
   return args.every((arg) => ARGUMENT_SAFE_PATTERN.test(arg) && arg.length <= MAX_ARGUMENT_LENGTH);
 }
 
-// Patterns are anchored to the start of the (normalized) relative path so that
-// a legitimate nested directory (e.g. "project/etc/config.md") is not rejected
-// just because it contains a protected name as a substring.
+// System-directory patterns are anchored to the start of the (normalized)
+// relative path so that a legitimate nested directory (e.g.
+// "project/etc/config.md") is not rejected merely for containing a protected
+// name as a substring. Hidden files/dirs are blocked at any depth so that
+// writes into ".git"/".config" (including nested, e.g. "sub/.git/hooks/...")
+// remain forbidden.
 const FORBIDDEN_OUTPUT_PATH_PATTERNS = [
-  /^\./, // hidden files/dirs (includes .git, .config, ...)
+  /^\./, // hidden file/dir at the root (.git, .config, ...)
+  /\/\.[^/]/, // hidden file/dir nested anywhere (e.g. "sub/.git/hooks")
   /^etc\//,
   /^root\//,
   /^home\//,

--- a/src/validators.ts
+++ b/src/validators.ts
@@ -1,0 +1,38 @@
+// Shared input validators used by both the CLI and its tests.
+// Keeping a single implementation here avoids drift between the security
+// checks enforced at runtime and the behavior asserted in tests.
+
+const ARGUMENT_SAFE_PATTERN = /^[a-zA-Z0-9._\-"/\\@#=\s,.:()[\]{}]+$/;
+const MAX_ARGUMENT_LENGTH = 200;
+
+export function validateArguments(args: string[]): boolean {
+  return args.every((arg) => ARGUMENT_SAFE_PATTERN.test(arg) && arg.length <= MAX_ARGUMENT_LENGTH);
+}
+
+// Patterns are anchored to the start of the (normalized) relative path so that
+// a legitimate nested directory (e.g. "project/etc/config.md") is not rejected
+// just because it contains a protected name as a substring.
+const FORBIDDEN_OUTPUT_PATH_PATTERNS = [
+  /^\./, // hidden files/dirs (includes .git, .config, ...)
+  /^etc\//,
+  /^root\//,
+  /^home\//,
+  /^usr\//,
+  /^var\//,
+  /^sys\//,
+  /^proc\//,
+];
+
+export function isValidOutputPath(filePath: string): boolean {
+  const normalized = filePath.replace(/\\/g, "/");
+
+  if (normalized.startsWith("/")) {
+    return false;
+  }
+
+  if (normalized.startsWith("..") || normalized.includes("/../")) {
+    return false;
+  }
+
+  return !FORBIDDEN_OUTPUT_PATH_PATTERNS.some((pattern) => pattern.test(normalized));
+}

--- a/src/validators.ts
+++ b/src/validators.ts
@@ -2,6 +2,8 @@
 // Keeping a single implementation here avoids drift between the security
 // checks enforced at runtime and the behavior asserted in tests.
 
+import { posix, win32 } from "node:path";
+
 const ARGUMENT_SAFE_PATTERN = /^[a-zA-Z0-9._\-"/\\@#=\s,.:()[\]{}]+$/;
 const MAX_ARGUMENT_LENGTH = 200;
 
@@ -18,19 +20,27 @@ export function validateArguments(args: string[]): boolean {
 const FORBIDDEN_OUTPUT_PATH_PATTERNS = [
   /^\./, // hidden file/dir at the root (.git, .config, ...)
   /\/\.[^/]/, // hidden file/dir nested anywhere (e.g. "sub/.git/hooks")
-  /^etc\//,
-  /^root\//,
-  /^home\//,
-  /^usr\//,
-  /^var\//,
-  /^sys\//,
-  /^proc\//,
+  /^etc(\/|$)/,
+  /^root(\/|$)/,
+  /^home(\/|$)/,
+  /^usr(\/|$)/,
+  /^var(\/|$)/,
+  /^sys(\/|$)/,
+  /^proc(\/|$)/,
 ];
 
 export function isValidOutputPath(filePath: string): boolean {
   const normalized = filePath.replace(/\\/g, "/");
 
-  if (normalized.startsWith("/")) {
+  // Reject both POSIX and Windows absolute forms regardless of the host OS, so
+  // the check is correct on Windows (the platform this hardening targets) and
+  // unit tests on macOS/Linux still exercise Windows paths.
+  const isAbsolute =
+    posix.isAbsolute(normalized) ||
+    win32.isAbsolute(filePath) ||
+    win32.isAbsolute(normalized) ||
+    /^[A-Za-z]:/.test(normalized);
+  if (isAbsolute) {
     return false;
   }
 

--- a/src/validators.ts
+++ b/src/validators.ts
@@ -11,42 +11,54 @@ export function validateArguments(args: string[]): boolean {
   return args.every((arg) => ARGUMENT_SAFE_PATTERN.test(arg) && arg.length <= MAX_ARGUMENT_LENGTH);
 }
 
-// System-directory patterns are anchored to the start of the (normalized)
-// relative path so that a legitimate nested directory (e.g.
-// "project/etc/config.md") is not rejected merely for containing a protected
-// name as a substring. Hidden files/dirs are blocked at any depth so that
-// writes into ".git"/".config" (including nested, e.g. "sub/.git/hooks/...")
-// remain forbidden.
-const FORBIDDEN_OUTPUT_PATH_PATTERNS = [
-  /^\./, // hidden file/dir at the root (.git, .config, ...)
-  /\/\.[^/]/, // hidden file/dir nested anywhere (e.g. "sub/.git/hooks")
-  /^etc(\/|$)/,
-  /^root(\/|$)/,
-  /^home(\/|$)/,
-  /^usr(\/|$)/,
-  /^var(\/|$)/,
-  /^sys(\/|$)/,
-  /^proc(\/|$)/,
-];
+export type OutputPathRejection = "absolute" | "escape" | "hidden" | "protected";
+export type OutputPathValidation = { ok: true } | { ok: false; reason: OutputPathRejection };
 
-export function isValidOutputPath(filePath: string): boolean {
-  const normalized = filePath.replace(/\\/g, "/");
+// First path segment names that map to sensitive system directories. Only the
+// leading segment matters: a relative "./etc/foo" is not the system "/etc".
+const PROTECTED_ROOT_SEGMENTS = new Set(["etc", "root", "home", "usr", "var", "sys", "proc"]);
 
+function isAbsolutePath(filePath: string, normalized: string): boolean {
   // Reject both POSIX and Windows absolute forms regardless of the host OS, so
   // the check is correct on Windows (the platform this hardening targets) and
   // unit tests on macOS/Linux still exercise Windows paths.
-  const isAbsolute =
+  return (
     posix.isAbsolute(normalized) ||
     win32.isAbsolute(filePath) ||
     win32.isAbsolute(normalized) ||
-    /^[A-Za-z]:/.test(normalized);
-  if (isAbsolute) {
-    return false;
+    /^[A-Za-z]:/.test(normalized)
+  );
+}
+
+// Policy is expressed as an explicit path-segment model rather than a growing
+// matrix of anchored regexes: normalize separators, reject absolute paths, then
+// walk the segments rejecting traversal, hidden entries, and protected roots.
+export function checkOutputPath(filePath: string): OutputPathValidation {
+  const normalized = filePath.replace(/\\/g, "/");
+
+  if (isAbsolutePath(filePath, normalized)) {
+    return { ok: false, reason: "absolute" };
   }
 
-  if (normalized.startsWith("..") || normalized.includes("/../")) {
-    return false;
+  const segments = normalized.split("/").filter((segment) => segment.length > 0);
+
+  for (const segment of segments) {
+    if (segment === "..") {
+      return { ok: false, reason: "escape" };
+    }
+    if (segment.startsWith(".")) {
+      return { ok: false, reason: "hidden" };
+    }
   }
 
-  return !FORBIDDEN_OUTPUT_PATH_PATTERNS.some((pattern) => pattern.test(normalized));
+  const firstSegment = segments[0];
+  if (firstSegment && PROTECTED_ROOT_SEGMENTS.has(firstSegment)) {
+    return { ok: false, reason: "protected" };
+  }
+
+  return { ok: true };
+}
+
+export function isValidOutputPath(filePath: string): boolean {
+  return checkOutputPath(filePath).ok;
 }


### PR DESCRIPTION
## Summary

Fixes the concrete, valid issues from `.planning/codebase/CONCERNS.md`. Scope is limited to real bugs + low-risk tech-debt/doc fixes; large speculative rewrites (spawn-array refactor, TUI rewrite, install.sh rewrite, new integration test suites) are intentionally left out. All 188 tests pass and `bun run ci` is green.

### What & why

**1. Windows tool detection was completely broken** (`src/detect.ts`)
`commandExists` unconditionally spawned `which`, which doesn't exist on Windows, so no tools were ever auto-detected there.
```ts
- const result = spawnSync("which", [command], {...});
+ const lookupCommand = process.platform === "win32" ? "where" : "which";
+ const result = spawnSync(lookupCommand, [command], {...});
```

**2. Validation logic duplicated/diverging between source and tests** (new `src/validators.ts`)
`index.test.ts` reimplemented `validateArguments` / `isValidOutputPath` / `validateToolCommand` as local copies that could (and did) drift from the real checks. Extracted the real validators into `src/validators.ts`, imported them in both `index.ts` and the tests, and pointed the test's `validateToolCommand` at the real `isSafeCommand`.

**3. Over-broad output-path rejection (substring match)** (`src/validators.ts`)
Forbidden dirs were matched anywhere in the path, so a legit nested dir like `project/etc/config.md` was rejected. Anchored the patterns to the start of the relative path:
```ts
-  /etc\//, /home\//, /usr\//, ...        // matched "etc/" anywhere
+  /^etc\//, /^home\//, /^usr\//, ...     // only the leading segment
```
All existing rejection tests still pass (they all start with the protected segment); added a test for the previously-broken nested case.

**4. Unbounded stdin slurp** (`src/index.ts`)
`readStdin` read all of fd 0 with no cap; a huge pipe could OOM the launcher. Added a 10MB limit (mirrors the existing git-diff cap) with an early error.

**5. Upgrade network calls could hang forever** (`src/upgrade.ts`)
`fetch` had no timeout. Wrapped the three calls in `fetchWithTimeout` using `AbortSignal.timeout(30s)`.

**6. Detection re-spawned processes on every call** (`src/detect.ts`)
`detectInstalledTools` runs several `which`/`ccs`/`gh` spawns. Memoized the result within the process (with `resetDetectionCache()` for tests).

**7. Docs out of date** (`AGENTS.md`)
Architecture list was missing `cli/diff.ts`, `errors.ts`, `git-diff.ts`, `prompts.ts`, `validators.ts`, and wrongly claimed `version.ts` is `.gitignore`d (it is committed and regenerated at build). Corrected both.

### Not addressed (and why)
- `buildTemplateCommand` only replacing the first `$@`: already prevented upstream by `validateTemplate` rejecting >1 `$@` at config load; changing it would break an explicit test. Noted rather than changed.
- Security hardening (argument-array spawning, signatures on upgrade), TUI robustness, `install.sh` JSON parsing, and the large test-coverage gaps are broader efforts beyond this fix pass.

## Test plan
- `bun run typecheck` — clean
- `bun run check` — clean (pre-existing biome schema-version info only)
- `bun test` — 188 pass / 0 fail
- `bun run build` — compiles `dist/ai`
- `bun run src/index.ts --version` / `--help` — work as before


Link to Devin session: https://app.devin.ai/sessions/7b54dc8d7aeb434caefe33f9f94b48ae
Requested by: @jellydn
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/jellydn/ai-launcher/pull/74" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Security & Reliability**
  * Added stricter validation for command arguments and output paths, including protection against traversal and sensitive directories.
  * Limited stdin input size to prevent excessive memory use.
  * Added 30-second timeouts for upgrade downloads and release checks.

* **Bug Fixes**
  * Improved tool detection on Windows and avoided false positives from built-in commands.
  * Cached tool detection results for more consistent CLI behavior.

* **Documentation**
  * Updated architecture documentation to reflect current modules and build-generated version information.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->