### PR TITLE
feat: add Interpreter and Devin CLI support

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@
 ## ✨ Features
 
 - **🔍 Fuzzy Search**: Interactive terminal UI with real-time filtering and keyboard navigation
-- **🔧 Auto-Detection**: Automatically finds installed AI CLIs (claude, gemini, agy, opencode, amp, copilot, codex, kilo, pi, droid, ollama, cursor, ccs, cmd, freebuff, grok)
+- **🔧 Auto-Detection**: Automatically finds installed AI CLIs (claude, gemini, agy, opencode, amp, copilot, codex, interpreter, devin, kilo, pi, droid, ollama, cursor, ccs, cmd, freebuff, grok)
 - **⚡ Direct Invocation**: Skip the menu with `ai <toolname>` or fuzzy matching
 - **🏷️ Aliases**: Define short aliases for frequently used tools (e.g., `ai c` for claude)
 - **📋 Templates**: Create command shortcuts with `$@` argument/stdin placeholders
@@ -402,6 +402,8 @@ The following CLIs are auto-detected if installed and available in PATH:
 - `amp` - Sourcegraph Amp CLI
 - `copilot` - GitHub Copilot CLI
 - `codex` - OpenAI Codex CLI
+- `interpreter` (`i`) - Open Interpreter CLI
+- `devin` - Devin CLI
 - `kilo` - Kilo Code CLI
 - `pi` - Pi AI CLI
 - `droid` - Factory Droid CLI

--- a/src/detect.test.ts
+++ b/src/detect.test.ts
@@ -252,6 +252,29 @@ describe("detectInstalledTools", () => {
     expect(mimo?.promptCommand).toBe("mimo run");
   });
 
+  test("interpreter is in KNOWN_TOOLS with correct configuration", () => {
+    const interpreter = KNOWN_TOOLS.find((t) => t.name === "interpreter") as
+      | KnownToolDefinition
+      | undefined;
+
+    expect(interpreter).toBeDefined();
+    expect(interpreter?.name).toBe("interpreter");
+    expect(interpreter?.command).toBe("interpreter");
+    expect(interpreter?.aliases).toEqual(["i"]);
+    expect(interpreter?.description).toBe("Open Interpreter CLI");
+    expect(interpreter?.promptCommand).toBe("interpreter exec");
+  });
+
+  test("devin is in KNOWN_TOOLS with correct configuration", () => {
+    const devin = KNOWN_TOOLS.find((t) => t.name === "devin");
+
+    expect(devin).toBeDefined();
+    expect(devin?.name).toBe("devin");
+    expect(devin?.command).toBe("devin");
+    expect(devin?.description).toBe("Devin CLI");
+    expect(devin?.promptCommand).toBe("devin -p");
+  });
+
   test("returns only installed tools from KNOWN_TOOLS", () => {
     const tools = detectInstalledTools();
 

--- a/src/detect.ts
+++ b/src/detect.ts
@@ -5,6 +5,7 @@ export type KnownToolDefinition = {
   name: string;
   command: string;
   description: string;
+  aliases?: string[];
   execCommand?: string;
   promptCommand?: string;
   promptUseStdin?: boolean;
@@ -60,6 +61,19 @@ export const KNOWN_TOOLS = [
     command: "codex",
     description: "OpenAI Codex CLI",
     promptCommand: "codex exec",
+  },
+  {
+    name: "interpreter",
+    command: "interpreter",
+    aliases: ["i"],
+    description: "Open Interpreter CLI",
+    promptCommand: "interpreter exec",
+  },
+  {
+    name: "devin",
+    command: "devin",
+    description: "Devin CLI",
+    promptCommand: "devin -p",
   },
   {
     name: "kilo",
@@ -282,6 +296,7 @@ export function detectInstalledTools(): Tool[] {
         name: tool.name,
         command: tool.execCommand ?? tool.command,
         description: tool.description,
+        aliases: tool.aliases,
         promptCommand: tool.promptCommand,
         promptUseStdin: tool.promptUseStdin,
       });

--- a/src/detect.ts
+++ b/src/detect.ts
@@ -5,7 +5,7 @@ export type KnownToolDefinition = {
   name: string;
   command: string;
   description: string;
-  aliases?: string[];
+  aliases?: readonly string[];
   execCommand?: string;
   promptCommand?: string;
   promptUseStdin?: boolean;
@@ -296,7 +296,7 @@ export function detectInstalledTools(): Tool[] {
         name: tool.name,
         command: tool.execCommand ?? tool.command,
         description: tool.description,
-        aliases: tool.aliases,
+        aliases: tool.aliases ? [...tool.aliases] : undefined,
         promptCommand: tool.promptCommand,
         promptUseStdin: tool.promptUseStdin,
       });


### PR DESCRIPTION
Adds auto-detection for:

- **Open Interpreter** (`interpreter`) with alias `i` and `interpreter exec` for prompt/diff flows
- **Devin CLI** (`devin`) with `devin -p` for non-interactive prompts

Updates README auto-detection lists. Tests added in `detect.test.ts`.