### PR TITLE
feat: add typed and versioned prompt registry

### DIFF
--- a/.changeset/typed-prompt-registry.md
+++ b/.changeset/typed-prompt-registry.md
@@ -1,0 +1,5 @@
+---
+"ai-launcher": minor
+---
+
+Add typed, versioned prompt templates for summarization, input classification, and meeting extraction, with prompt listing and inspection commands.

--- a/README.md
+++ b/README.md
@@ -283,6 +283,29 @@ OPENROUTER_API_KEY=... ai meeting meeting.md --openrouter
 
 By default it prints a human-readable summary. Pass `--json` for machine-readable JSON.
 
+## Prompt templates
+
+The built-in AI workflows use typed, versioned prompt templates. System instructions and user
+content are rendered separately, and variables are validated before a provider receives them.
+
+```bash
+ai prompt list
+ai prompt inspect summarize-content
+ai prompt inspect classify-input
+ai prompt inspect extract-meeting
+```
+
+Templates live in `src/prompts/`. To add one:
+
+1. Define a Zod schema with clearly named variables.
+2. Create it with `definePrompt()`, including a stable ID, semantic version, description, variable
+   metadata, and output fields.
+3. Return separate `system` and `user` messages from `render()`.
+4. Register it in `src/prompts/registry.ts` and add rendering and validation tests.
+
+Increment a template's version whenever its rendered instructions or expected output contract
+changes. Consumers can use the version to evaluate prompt changes independently from CLI releases.
+
 ## Configuration
 
 Config file location: `~/.config/ai-launcher/config.json`

--- a/src/index.ts
+++ b/src/index.ts
@@ -322,22 +322,27 @@ function getSummaryArgsFromTemplate(command: string, userArgs: string[]): string
   return [...strippedFlags, ...userArgs];
 }
 
-export function runPromptCommand(args: string[]): void {
+const PROMPT_ID_PATTERN = /^[a-z0-9-]+$/;
+
+export function runPromptCommand(args: string[]): { success: boolean; error?: string } {
   if (args[0] === "list") {
     console.log(formatPromptList());
-    return;
+    return { success: true };
   }
 
   if (args[0] === "inspect" && args[1]) {
+    if (!PROMPT_ID_PATTERN.test(args[1])) {
+      return { success: false, error: `Invalid prompt ID format: ${args[1]}` };
+    }
     const inspection = formatPromptInspection(args[1]);
     if (!inspection) {
-      throw new Error(`Unknown prompt: ${args[1]}`);
+      return { success: false, error: `Unknown prompt: ${args[1]}` };
     }
     console.log(inspection);
-    return;
+    return { success: true };
   }
 
-  throw new Error("Usage: ai prompt list | ai prompt inspect <id>");
+  return { success: false, error: "Usage: ai prompt list | ai prompt inspect <id>" };
 }
 
 async function main() {
@@ -368,7 +373,11 @@ async function main() {
   }
 
   if (args[0] === "prompt") {
-    runPromptCommand(args.slice(1));
+    const result = runPromptCommand(args.slice(1));
+    if (!result.success) {
+      console.error(result.error);
+      process.exit(1);
+    }
     return;
   }
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -11,6 +11,7 @@ import { fuzzySelect, promptForInput, toSelectableItems } from "./fuzzy-select";
 import { getColoredLogo } from "./logo";
 import { findToolByName, type LookupResult } from "./lookup";
 import { main as meetingMain } from "./meeting/index.ts";
+import { formatPromptInspection, formatPromptList } from "./prompts/registry.ts";
 import { main as summaryMain } from "./summary/index.ts";
 import { isSafeCommand, parseTemplateCommand } from "./template";
 import type { SelectableItem } from "./types";
@@ -131,6 +132,8 @@ OPTIONS:
 BUILT-IN:
     summary                          Summarize files, URLs, or stdin (see: ai summary --help)
     meeting                          Extract summary, actions, risks from notes (see: ai meeting --help)
+    prompt list                      List reusable prompt templates
+    prompt inspect <id>              Inspect a prompt's variables and output
 
 EXAMPLES:
     ai                               Launch fuzzy search
@@ -152,6 +155,9 @@ EXAMPLES:
     ai meeting notes.md --openrouter Use OpenRouter (OPENROUTER_API_KEY)
     cat transcript.md | ai meeting --json
                                      JSON: summary, action_items, risks
+    ai prompt list                   List prompt IDs and versions
+    ai prompt inspect extract-meeting
+                                     Inspect the meeting extraction prompt
     ai upgrade                       Upgrade to latest version
 
 CONFIG:
@@ -316,6 +322,24 @@ function getSummaryArgsFromTemplate(command: string, userArgs: string[]): string
   return [...strippedFlags, ...userArgs];
 }
 
+export function runPromptCommand(args: string[]): void {
+  if (args[0] === "list") {
+    console.log(formatPromptList());
+    return;
+  }
+
+  if (args[0] === "inspect" && args[1]) {
+    const inspection = formatPromptInspection(args[1]);
+    if (!inspection) {
+      throw new Error(`Unknown prompt: ${args[1]}`);
+    }
+    console.log(inspection);
+    return;
+  }
+
+  throw new Error("Usage: ai prompt list | ai prompt inspect <id>");
+}
+
 async function main() {
   const args = process.argv.slice(2);
 
@@ -340,6 +364,11 @@ async function main() {
 
   if (args[0] === "meeting") {
     await meetingMain(args.slice(1));
+    return;
+  }
+
+  if (args[0] === "prompt") {
+    runPromptCommand(args.slice(1));
     return;
   }
 

--- a/src/meeting/prompt.ts
+++ b/src/meeting/prompt.ts
@@ -1,22 +1,7 @@
-export const INSTRUCTIONS = `You are a structured meeting assistant.
+import { extractMeetingPrompt, MEETING_INSTRUCTIONS } from "../prompts/extract-meeting.ts";
 
-Extract from the meeting transcript or notes:
-1. A concise summary (2-4 sentences)
-2. Action items with: owner, task, and due date/timeframe
-3. Risks, blockers, or concerns
-
-Output must be a JSON object matching this schema:
-{
-  "summary": "...",
-  "action_items": [
-    {"owner": "...", "task": "...", "due": "..."}
-  ],
-  "risks": ["..."]
-}
-
-Use empty arrays for action_items and risks if none are present.
-Be specific, concise, and do not hallucinate details not in the transcript.`;
+export const INSTRUCTIONS = MEETING_INSTRUCTIONS;
 
 export function buildMeetingPrompt(transcript: string): string {
-  return `Transcript:\n"""\n${transcript}\n"""`;
+  return extractMeetingPrompt.render({ transcript }).user;
 }

--- a/src/meeting/summarize.ts
+++ b/src/meeting/summarize.ts
@@ -2,7 +2,7 @@
 import OpenAI from "openai";
 import { zodResponseFormat } from "openai/helpers/zod";
 import type { MeetingSummary } from "./schema.ts";
-import { buildMeetingPrompt, INSTRUCTIONS } from "./prompt.ts";
+import { extractMeetingPrompt } from "../prompts/extract-meeting.ts";
 import { MeetingSummarySchema } from "./schema.ts";
 
 export interface SummarizeOptions {
@@ -33,12 +33,13 @@ export async function summarizeMeeting(
   });
 
   const responseFormat = zodResponseFormat(MeetingSummarySchema, "meeting_summary");
+  const prompt = extractMeetingPrompt.render({ transcript });
 
   const stream = client.chat.completions.stream({
     model: options.model ?? DEFAULT_MODEL,
     messages: [
-      { role: "system", content: INSTRUCTIONS },
-      { role: "user", content: buildMeetingPrompt(transcript) },
+      { role: "system", content: prompt.system },
+      { role: "user", content: prompt.user },
     ],
     temperature: options.temperature ?? DEFAULT_TEMPERATURE,
     response_format: responseFormat,

--- a/src/prompts/classify.ts
+++ b/src/prompts/classify.ts
@@ -1,0 +1,42 @@
+import { z } from "zod";
+import { definePrompt } from "./render.ts";
+
+export const inputCategorySchema = z.enum([
+  "article",
+  "meeting",
+  "git-diff",
+  "email",
+  "code",
+  "unknown",
+]);
+
+const classifyVariablesSchema = z.object({
+  content: z.string().min(1, "content is required"),
+});
+
+export type InputCategory = z.infer<typeof inputCategorySchema>;
+export type ClassifyVariables = z.infer<typeof classifyVariablesSchema>;
+
+export const classifyPrompt = definePrompt({
+  id: "classify-input",
+  version: "1.0.0",
+  description: "Classify input so the launcher can recommend an appropriate workflow.",
+  variables: [
+    { name: "content", type: "string", required: true, description: "Content to classify" },
+  ],
+  output: ["category", "confidence", "reason"],
+  schema: classifyVariablesSchema,
+  render: ({ content }) => ({
+    system: `You classify content for an AI workflow router.
+
+Return only JSON with this shape:
+{
+  "category": "article | meeting | git-diff | email | code | unknown",
+  "confidence": 0.0,
+  "reason": "Brief evidence-based explanation"
+}
+
+Confidence must be between 0 and 1. Use "unknown" when the evidence is ambiguous.`,
+    user: `Classify this content:\n\n---\n${content}\n---`,
+  }),
+});

--- a/src/prompts/classify.ts
+++ b/src/prompts/classify.ts
@@ -36,7 +36,7 @@ Return only JSON with this shape:
   "reason": "Brief evidence-based explanation"
 }
 
-Confidence must be between 0 and 1. Use "unknown" when the evidence is ambiguous.`,
+Confidence must be between 0 and 1. Use "unknown" when the evidence is ambiguous. Do not use markdown code fences or add commentary.`,
     user: `Classify this content:\n\n---\n${content}\n---`,
   }),
 });

--- a/src/prompts/extract-meeting.ts
+++ b/src/prompts/extract-meeting.ts
@@ -1,0 +1,47 @@
+import { z } from "zod";
+import { definePrompt } from "./render.ts";
+
+const meetingVariablesSchema = z.object({
+  transcript: z.string().min(1, "transcript is required"),
+});
+
+export type MeetingVariables = z.infer<typeof meetingVariablesSchema>;
+
+export const MEETING_INSTRUCTIONS = `You are a structured meeting assistant.
+
+Extract from the meeting transcript or notes:
+1. A concise summary (2-4 sentences)
+2. Action items with: owner, task, and due date/timeframe
+3. Risks, blockers, or concerns
+
+Output must be a JSON object matching this schema:
+{
+  "summary": "...",
+  "action_items": [
+    {"owner": "...", "task": "...", "due": "..."}
+  ],
+  "risks": ["..."]
+}
+
+Use empty arrays for action_items and risks if none are present.
+Be specific, concise, and do not hallucinate details not in the transcript.`;
+
+export const extractMeetingPrompt = definePrompt({
+  id: "extract-meeting",
+  version: "1.0.0",
+  description: "Extract a summary, action items, and risks from meeting notes.",
+  variables: [
+    {
+      name: "transcript",
+      type: "string",
+      required: true,
+      description: "Meeting transcript or notes",
+    },
+  ],
+  output: ["summary", "action_items", "risks"],
+  schema: meetingVariablesSchema,
+  render: ({ transcript }) => ({
+    system: MEETING_INSTRUCTIONS,
+    user: `Transcript:\n"""\n${transcript}\n"""`,
+  }),
+});

--- a/src/prompts/prompts.test.ts
+++ b/src/prompts/prompts.test.ts
@@ -1,5 +1,4 @@
 import { describe, expect, test } from "bun:test";
-import { ZodError } from "zod";
 import { classifyPrompt } from "./classify.ts";
 import { extractMeetingPrompt } from "./extract-meeting.ts";
 import { formatPromptInspection, formatPromptList, getPrompt } from "./registry.ts";
@@ -7,9 +6,11 @@ import { summarizePrompt } from "./summarize.ts";
 
 describe("prompt registry", () => {
   test("lists stable prompt IDs and versions", () => {
-    expect(formatPromptList()).toBe(
-      "summarize-content  v1.0.0\nclassify-input     v1.0.0\nextract-meeting    v1.0.0"
-    );
+    const list = formatPromptList();
+    expect(list).toContain("summarize-content");
+    expect(list).toContain("classify-input");
+    expect(list).toContain("extract-meeting");
+    expect(list).toContain("v1.0.0");
   });
 
   test("finds and describes a prompt", () => {
@@ -18,6 +19,7 @@ describe("prompt registry", () => {
     expect(prompt.render({ transcript: "Weekly sync" }).user).toContain("Weekly sync");
     expect(formatPromptInspection("extract-meeting")).toContain("transcript: string, required");
     expect(formatPromptInspection("missing")).toBeUndefined();
+    expect(getPrompt("toString")).toBeUndefined();
   });
 });
 
@@ -39,7 +41,9 @@ describe("summarize prompt", () => {
   });
 
   test("validates required variables", () => {
-    expect(() => summarizePrompt.render({ content: "", mode: "tldr" })).toThrow(ZodError);
+    expect(() => summarizePrompt.render({ content: "", mode: "tldr" })).toThrow(
+      /Validation failed for prompt "summarize-content".*content is required/
+    );
   });
 });
 
@@ -49,6 +53,7 @@ describe("classification prompt", () => {
 
     expect(prompt.system).toContain("article | meeting | git-diff | email | code | unknown");
     expect(prompt.system).toContain('"confidence"');
+    expect(prompt.system).toContain("Do not use markdown code fences");
     expect(prompt.user).toContain("diff --git a/file.ts b/file.ts");
   });
 });
@@ -65,6 +70,8 @@ describe("meeting extraction prompt", () => {
   });
 
   test("rejects a missing transcript", () => {
-    expect(() => extractMeetingPrompt.render({ transcript: "" })).toThrow("transcript is required");
+    expect(() => extractMeetingPrompt.render({ transcript: "" })).toThrow(
+      /Validation failed for prompt "extract-meeting".*transcript is required/
+    );
   });
 });

--- a/src/prompts/prompts.test.ts
+++ b/src/prompts/prompts.test.ts
@@ -1,0 +1,70 @@
+import { describe, expect, test } from "bun:test";
+import { ZodError } from "zod";
+import { classifyPrompt } from "./classify.ts";
+import { extractMeetingPrompt } from "./extract-meeting.ts";
+import { formatPromptInspection, formatPromptList, getPrompt } from "./registry.ts";
+import { summarizePrompt } from "./summarize.ts";
+
+describe("prompt registry", () => {
+  test("lists stable prompt IDs and versions", () => {
+    expect(formatPromptList()).toBe(
+      "summarize-content  v1.0.0\nclassify-input     v1.0.0\nextract-meeting    v1.0.0"
+    );
+  });
+
+  test("finds and describes a prompt", () => {
+    const prompt = getPrompt("extract-meeting");
+    expect(prompt).toBe(extractMeetingPrompt);
+    expect(prompt.render({ transcript: "Weekly sync" }).user).toContain("Weekly sync");
+    expect(formatPromptInspection("extract-meeting")).toContain("transcript: string, required");
+    expect(formatPromptInspection("missing")).toBeUndefined();
+  });
+});
+
+describe("summarize prompt", () => {
+  test("separates instructions from user content and renders optional constraints", () => {
+    const prompt = summarizePrompt.render({
+      content: "Bun released a faster test runner.",
+      mode: "technical",
+      audience: "TypeScript developers",
+      maxLength: 100,
+    });
+
+    expect(prompt.system).toContain("summarization assistant");
+    expect(prompt.system).toContain('"action_items"');
+    expect(prompt.user).toContain("technical:");
+    expect(prompt.user).toContain("Write for TypeScript developers.");
+    expect(prompt.user).toContain("within 100 words");
+    expect(prompt.user).toContain("Bun released a faster test runner.");
+  });
+
+  test("validates required variables", () => {
+    expect(() => summarizePrompt.render({ content: "", mode: "tldr" })).toThrow(ZodError);
+  });
+});
+
+describe("classification prompt", () => {
+  test("renders the supported categories and content", () => {
+    const prompt = classifyPrompt.render({ content: "diff --git a/file.ts b/file.ts" });
+
+    expect(prompt.system).toContain("article | meeting | git-diff | email | code | unknown");
+    expect(prompt.system).toContain('"confidence"');
+    expect(prompt.user).toContain("diff --git a/file.ts b/file.ts");
+  });
+});
+
+describe("meeting extraction prompt", () => {
+  test("keeps stable structured-output and anti-hallucination instructions", () => {
+    const prompt = extractMeetingPrompt.render({ transcript: "Alex will ship on Friday." });
+
+    expect(prompt.system).toContain('"summary": "..."');
+    expect(prompt.system).toContain('"action_items"');
+    expect(prompt.system).toContain('"risks"');
+    expect(prompt.system).toContain("do not hallucinate");
+    expect(prompt.user).toBe('Transcript:\n"""\nAlex will ship on Friday.\n"""');
+  });
+
+  test("rejects a missing transcript", () => {
+    expect(() => extractMeetingPrompt.render({ transcript: "" })).toThrow("transcript is required");
+  });
+});

--- a/src/prompts/registry.ts
+++ b/src/prompts/registry.ts
@@ -1,0 +1,51 @@
+import { classifyPrompt } from "./classify.ts";
+import { extractMeetingPrompt } from "./extract-meeting.ts";
+import { summarizePrompt } from "./summarize.ts";
+
+const promptById = {
+  "summarize-content": summarizePrompt,
+  "classify-input": classifyPrompt,
+  "extract-meeting": extractMeetingPrompt,
+} as const;
+
+export const promptRegistry = Object.values(promptById);
+
+export type PromptId = keyof typeof promptById;
+type RegisteredPrompt = (typeof promptRegistry)[number];
+type PromptById<TId extends PromptId> = (typeof promptById)[TId];
+
+export function getPrompt<TId extends PromptId>(id: TId): PromptById<TId>;
+export function getPrompt(id: string): RegisteredPrompt | undefined;
+export function getPrompt(id: string): RegisteredPrompt | undefined {
+  return promptById[id as PromptId];
+}
+
+export function formatPromptList(): string {
+  const idWidth = Math.max(...promptRegistry.map((prompt) => prompt.id.length)) + 2;
+  return promptRegistry
+    .map((prompt) => `${prompt.id.padEnd(idWidth)}v${prompt.version}`)
+    .join("\n");
+}
+
+export function formatPromptInspection(id: string): string | undefined {
+  const prompt = getPrompt(id);
+  if (!prompt) {
+    return undefined;
+  }
+
+  const variables = prompt.variables.map(
+    (variable) =>
+      `  - ${variable.name}: ${variable.type}, ${variable.required ? "required" : "optional"} — ${variable.description}`
+  );
+  const output = prompt.output.map((field) => `  - ${field}`);
+
+  return [
+    `ID: ${prompt.id}`,
+    `Version: ${prompt.version}`,
+    `Description: ${prompt.description}`,
+    "Variables:",
+    ...variables,
+    "Output:",
+    ...output,
+  ].join("\n");
+}

--- a/src/prompts/registry.ts
+++ b/src/prompts/registry.ts
@@ -17,6 +17,9 @@ type PromptById<TId extends PromptId> = (typeof promptById)[TId];
 export function getPrompt<TId extends PromptId>(id: TId): PromptById<TId>;
 export function getPrompt(id: string): RegisteredPrompt | undefined;
 export function getPrompt(id: string): RegisteredPrompt | undefined {
+  if (!Object.hasOwn(promptById, id)) {
+    return undefined;
+  }
   return promptById[id as PromptId];
 }
 
@@ -33,10 +36,10 @@ export function formatPromptInspection(id: string): string | undefined {
     return undefined;
   }
 
-  const variables = prompt.variables.map(
-    (variable) =>
-      `  - ${variable.name}: ${variable.type}, ${variable.required ? "required" : "optional"} — ${variable.description}`
-  );
+  const variables = prompt.variables.map((variable) => {
+    const req = variable.required ? "required" : "optional";
+    return `  - ${variable.name}: ${variable.type}, ${req} — ${variable.description}`;
+  });
   const output = prompt.output.map((field) => `  - ${field}`);
 
   return [

--- a/src/prompts/render.ts
+++ b/src/prompts/render.ts
@@ -1,3 +1,4 @@
+import { ZodError } from "zod";
 import type { PromptTemplate, PromptTemplateDefinition } from "./types.ts";
 
 export function definePrompt<TVariables>(
@@ -9,6 +10,21 @@ export function definePrompt<TVariables>(
     description: definition.description,
     variables: definition.variables,
     output: definition.output,
-    render: (variables) => definition.render(definition.schema.parse(variables)),
+    render: (variables) => {
+      try {
+        return definition.render(definition.schema.parse(variables));
+      } catch (error) {
+        if (error instanceof ZodError) {
+          const issues = error.issues
+            .map((issue) => {
+              const path = issue.path.length > 0 ? issue.path.join(".") : "input";
+              return `${path}: ${issue.message}`;
+            })
+            .join(", ");
+          throw new Error(`Validation failed for prompt "${definition.id}": ${issues}`);
+        }
+        throw error;
+      }
+    },
   };
 }

--- a/src/prompts/render.ts
+++ b/src/prompts/render.ts
@@ -1,0 +1,14 @@
+import type { PromptTemplate, PromptTemplateDefinition } from "./types.ts";
+
+export function definePrompt<TVariables>(
+  definition: PromptTemplateDefinition<TVariables>
+): PromptTemplate<TVariables> {
+  return {
+    id: definition.id,
+    version: definition.version,
+    description: definition.description,
+    variables: definition.variables,
+    output: definition.output,
+    render: (variables) => definition.render(definition.schema.parse(variables)),
+  };
+}

--- a/src/prompts/summarize.ts
+++ b/src/prompts/summarize.ts
@@ -1,0 +1,97 @@
+import { z } from "zod";
+import { definePrompt } from "./render.ts";
+
+const summaryVariablesSchema = z.object({
+  content: z.string().min(1, "content is required"),
+  mode: z.enum(["tldr", "actions", "linkedin", "technical"]),
+  maxLength: z.number().int().positive().optional(),
+  audience: z.string().min(1).optional(),
+  category: z.enum(["article", "email", "newsletter", "unknown"]).optional(),
+  source: z.string().min(1).optional(),
+});
+
+export type SummarizeVariables = z.infer<typeof summaryVariablesSchema>;
+
+export const SUMMARY_JSON_SCHEMA = `{
+  "title": "Optional detected title",
+  "summary": "A concise 3-5 sentence summary",
+  "key_points": [
+    "Main point one",
+    "Main point two"
+  ],
+  "action_items": [
+    "Reply to the sender",
+    "Review the linked document"
+  ],
+  "category": "newsletter",
+  "importance": "medium"
+}`;
+
+const modeInstructions: Record<SummarizeVariables["mode"], string> = {
+  tldr: "Provide a concise 3-5 sentence summary. Keep key_points and action_items short and focused.",
+  actions:
+    "Focus on deadlines, tasks, and action_items. Extract every actionable item and explicitly mention any deadlines or dates.",
+  linkedin:
+    "Turn the content into a short LinkedIn post draft. Use a professional, engaging tone and punchy key_points. Include a clear call to action in action_items if appropriate.",
+  technical:
+    "Preserve technical details, links, code snippets, and terminology. Be precise and do not oversimplify. Capture technical takeaways in key_points.",
+};
+
+export function getSummaryModeInstruction(mode: SummarizeVariables["mode"]): string {
+  return `${mode}: ${modeInstructions[mode]}`;
+}
+
+export const summarizePrompt = definePrompt({
+  id: "summarize-content",
+  version: "1.0.0",
+  description: "Summarize content for a chosen mode and audience.",
+  variables: [
+    { name: "content", type: "string", required: true, description: "Content to summarize" },
+    { name: "mode", type: "SummaryMode", required: true, description: "Summary style" },
+    {
+      name: "maxLength",
+      type: "positive integer",
+      required: false,
+      description: "Maximum summary length in words",
+    },
+    {
+      name: "audience",
+      type: "string",
+      required: false,
+      description: "Intended reader",
+    },
+    {
+      name: "category",
+      type: "SummaryCategory",
+      required: false,
+      description: "Detected content category",
+    },
+    { name: "source", type: "string", required: false, description: "Content source label" },
+  ],
+  output: ["title", "summary", "key_points", "action_items", "category", "importance"],
+  schema: summaryVariablesSchema,
+  render: ({ content, mode, maxLength, audience, category = "unknown", source = "input" }) => {
+    const contentType = category === "unknown" ? "content" : category;
+    const constraints = [
+      audience ? `Write for ${audience}.` : undefined,
+      maxLength ? `Keep the summary within ${maxLength} words.` : undefined,
+    ].filter((value): value is string => value !== undefined);
+
+    return {
+      system: `You are a summarization assistant. Return only a JSON object matching this schema:\n\n${SUMMARY_JSON_SCHEMA}`,
+      user: `Summarize the following ${contentType} from ${source}.
+
+Instructions:
+- Pick the category from "article", "email", "newsletter", or "unknown" based on the content.
+- Pick the importance from "low", "medium", or "high" based on urgency and relevance.
+- Include the title only if one can be detected or inferred from the content.
+- ${getSummaryModeInstruction(mode)}${constraints.length > 0 ? `\n- ${constraints.join("\n- ")}` : ""}
+- Return only JSON. Do not use markdown code fences or add commentary.
+
+Content:
+---
+${content}
+---`,
+    };
+  },
+});

--- a/src/prompts/types.ts
+++ b/src/prompts/types.ts
@@ -1,0 +1,28 @@
+import type { z } from "zod";
+
+export interface PromptMessages {
+  system: string;
+  user: string;
+}
+
+export interface PromptVariable {
+  name: string;
+  type: string;
+  required: boolean;
+  description: string;
+}
+
+export interface PromptTemplate<TVariables> {
+  id: string;
+  version: string;
+  description: string;
+  variables: readonly PromptVariable[];
+  output: readonly string[];
+  render: (variables: TVariables) => PromptMessages;
+}
+
+export interface PromptTemplateDefinition<TVariables>
+  extends Omit<PromptTemplate<TVariables>, "render"> {
+  schema: z.ZodType<TVariables>;
+  render: (variables: TVariables) => PromptMessages;
+}

--- a/src/summary/detect.ts
+++ b/src/summary/detect.ts
@@ -1,3 +1,4 @@
+import { getSummaryModeInstruction } from "../prompts/summarize.ts";
 import type { SummaryCategory, SummaryMode } from "./schema.ts";
 
 const EMAIL_HEADERS = [
@@ -39,16 +40,5 @@ export function detectCategory(content: string): SummaryCategory {
 }
 
 export function getModeInstruction(mode: SummaryMode): string {
-  switch (mode) {
-    case "tldr":
-      return `tldr: Provide a concise 3-5 sentence summary. Keep key_points and action_items short and focused.`;
-    case "actions":
-      return `actions: Focus on deadlines, tasks, and action_items. Extract every actionable item and explicitly mention any deadlines or dates.`;
-    case "linkedin":
-      return `linkedin: Turn the content into a short LinkedIn post draft. The summary should be engaging, use a professional tone, and key_points should be punchy bullets. Include a clear call to action in action_items if appropriate.`;
-    case "technical":
-      return `technical: Preserve technical details, links, code snippets, and terminology. Be precise and do not oversimplify the technical content. Key_points should capture the technical takeaways.`;
-    default:
-      return `tldr`;
-  }
+  return getSummaryModeInstruction(mode);
 }

--- a/src/summary/index.ts
+++ b/src/summary/index.ts
@@ -1,11 +1,11 @@
 #!/usr/bin/env bun
 
 import { parseArgs } from "node:util";
+import { summarizePrompt } from "../prompts/summarize.ts";
 import { detectCategory } from "./detect.ts";
 import { resolveInput, SummaryInputError, SummaryUrlError } from "./input.ts";
 import { renderJson, renderMarkdown } from "./output.ts";
 import { extractJson } from "./parse-json.ts";
-import { buildSummaryPrompt } from "./prompts.ts";
 import { createProvider, ProviderError } from "./provider.ts";
 import type { Summary, SummaryMode } from "./schema.ts";
 import { parseSummary, summaryModeSchema } from "./schema.ts";
@@ -94,7 +94,7 @@ export async function main(argv = process.argv.slice(2)): Promise<void> {
 
   const { content, source } = await resolveInput(positionals);
   const category = detectCategory(content);
-  const prompt = buildSummaryPrompt({
+  const prompt = summarizePrompt.render({
     content,
     category,
     mode,
@@ -103,8 +103,8 @@ export async function main(argv = process.argv.slice(2)): Promise<void> {
 
   const stream = provider.generate({
     messages: [
-      { role: "system", content: "You are a helpful summarization assistant." },
-      { role: "user", content: prompt },
+      { role: "system", content: prompt.system },
+      { role: "user", content: prompt.user },
     ],
     temperature: 0.1,
   });

--- a/src/summary/prompts.ts
+++ b/src/summary/prompts.ts
@@ -1,20 +1,7 @@
-import { getModeInstruction } from "./detect.ts";
+import { SUMMARY_JSON_SCHEMA, summarizePrompt } from "../prompts/summarize.ts";
 import type { SummaryCategory, SummaryMode } from "./schema.ts";
 
-export const SUMMARY_JSON_SCHEMA = `{
-  "title": "Optional detected title",
-  "summary": "A concise 3-5 sentence summary",
-  "key_points": [
-    "Main point one",
-    "Main point two"
-  ],
-  "action_items": [
-    "Reply to the sender",
-    "Review the linked document"
-  ],
-  "category": "newsletter",
-  "importance": "medium"
-}`;
+export { SUMMARY_JSON_SCHEMA };
 
 export interface PromptInput {
   content: string;
@@ -24,22 +11,5 @@ export interface PromptInput {
 }
 
 export function buildSummaryPrompt(input: PromptInput): string {
-  const modeInstruction = getModeInstruction(input.mode);
-  const category = input.category === "unknown" ? "content" : input.category;
-
-  return `You are a summarization assistant. Read the following ${category} from ${input.source} and produce a JSON object that conforms to this schema:
-
-${SUMMARY_JSON_SCHEMA}
-
-Instructions:
-- Pick the category from "article", "email", "newsletter", or "unknown" based on the content.
-- Pick the importance from "low", "medium", or "high" based on urgency and relevance.
-- Include the title only if one can be detected or inferred from the content.
-- ${modeInstruction}
-- Return ONLY the JSON object. Do not wrap it in markdown code fences or add extra commentary.
-
-Content:
----
-${input.content}
----`;
+  return summarizePrompt.render(input).user;
 }


### PR DESCRIPTION
## Summary

- add a typed, versioned prompt registry with runtime variable validation
- move summary and meeting execution onto reusable templates with separate system/user messages
- add a classification template for future recommendation-only routing
- add `ai prompt list` and `ai prompt inspect <id>` commands
- document prompt authoring/versioning and add a changeset

## Test plan

- `bun run ci`
- `bun run build`
- `bun run src/index.ts prompt list`
- `bun run src/index.ts prompt inspect extract-meeting`

## Day 12 learning goals

- reusable prompts
- clearly named and validated variables
- maintainable prompt organization

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Introduced typed, versioned prompt templates for summarization, input classification, and meeting extraction.
  * Added `ai prompt list` and `ai prompt inspect <id>` to browse and review built-in templates.
  * Added input validation to ensure templates receive correct variables and produce structured JSON output.

* **Documentation**
  * Added a “Prompt templates” section describing how templates work and how to add/version new ones.

* **Bug Fixes**
  * Standardized summary and meeting flows to use the shared template outputs consistently.

* **Tests**
  * Added end-to-end tests covering template listing, inspection, rendering, and validation behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->