### PR TITLE
feat: add jcode to known AI tools

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@
 ## ✨ Features
 
 - **🔍 Fuzzy Search**: Interactive terminal UI with real-time filtering and keyboard navigation
-- **🔧 Auto-Detection**: Automatically finds installed AI CLIs (claude, cline, gemini, agy, opencode, amp, copilot, codex, interpreter, devin, kilo, kimi, mimo, pi, droid, ollama, cursor-agent, ccs, cmd, freebuff, grok, reasonix, omp, fx)
+- **🔧 Auto-Detection**: Automatically finds installed AI CLIs (claude, cline, gemini, agy, opencode, amp, copilot, codex, interpreter, devin, kilo, kimi, mimo, pi, droid, ollama, cursor-agent, ccs, cmd, freebuff, grok, reasonix, omp, fx, jcode)
 - **⚡ Direct Invocation**: Skip the menu with `ai <toolname>` or fuzzy matching
 - **🏷️ Aliases**: Define short aliases for frequently used tools (e.g., `ai c` for claude)
 - **📋 Templates**: Create command shortcuts with `$@` argument/stdin placeholders
@@ -450,6 +450,7 @@ The following CLIs are auto-detected if installed and available in PATH:
 - `reasonix` - Reasonix — DeepSeek-native terminal coding agent (multi-model)
 - `omp` - Oh My Pi CLI
 - `fx` - fx.sh coding agent (`fx` starts an interactive session; `fx ask` runs one request)
+- `jcode` - J-Code coding agent (Claude Max / ChatGPT Pro subscriptions)
 
 **Precedence Rules:**
 

--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@
 ## ✨ Features
 
 - **🔍 Fuzzy Search**: Interactive terminal UI with real-time filtering and keyboard navigation
-- **🔧 Auto-Detection**: Automatically finds installed AI CLIs (claude, cline, gemini, agy, opencode, amp, copilot, codex, interpreter, devin, kilo, kimi, mimo, pi, droid, ollama, cursor-agent, ccs, cmd, freebuff, grok)
+- **🔧 Auto-Detection**: Automatically finds installed AI CLIs (claude, cline, gemini, agy, opencode, amp, copilot, codex, interpreter, devin, kilo, kimi, mimo, pi, droid, ollama, cursor-agent, ccs, cmd, freebuff, grok, jcode)
 - **⚡ Direct Invocation**: Skip the menu with `ai <toolname>` or fuzzy matching
 - **🏷️ Aliases**: Define short aliases for frequently used tools (e.g., `ai c` for claude)
 - **📋 Templates**: Create command shortcuts with `$@` argument/stdin placeholders
@@ -446,6 +446,7 @@ The following CLIs are auto-detected if installed and available in PATH:
 - `cmd` - Command Code CLI
 - `freebuff` - Freebuff, free ad-supported AI coding agent (Codebuff variant)
 - `grok` - xAI Grok Build CLI
+- `jcode` - J-Code coding agent (Claude Max / ChatGPT Pro subscriptions)
 
 **Precedence Rules:**
 

--- a/docs/_README.md
+++ b/docs/_README.md
@@ -19,7 +19,7 @@
 ## ✨ Features
 
 - **🔍 Fuzzy Search**: Interactive terminal UI with real-time filtering and keyboard navigation
-- **🔧 Auto-Detection**: Automatically finds installed AI CLIs (claude, cline, gemini, agy, opencode, amp, copilot, codex, interpreter, devin, kilo, kimi, mimo, pi, droid, ollama, cursor-agent, ccs, cmd, freebuff, grok, reasonix, omp, fx)
+- **🔧 Auto-Detection**: Automatically finds installed AI CLIs (claude, cline, gemini, agy, opencode, amp, copilot, codex, interpreter, devin, kilo, kimi, mimo, pi, droid, ollama, cursor-agent, ccs, cmd, freebuff, grok, reasonix, omp, fx, jcode)
 - **⚡ Direct Invocation**: Skip the menu with `ai <toolname>` or fuzzy matching
 - **🏷️ Aliases**: Define short aliases for frequently used tools (e.g., `ai c` for claude)
 - **📋 Templates**: Create command shortcuts with `$@` argument/stdin placeholders
@@ -450,6 +450,7 @@ The following CLIs are auto-detected if installed and available in PATH:
 - `reasonix` - Reasonix — DeepSeek-native terminal coding agent (multi-model)
 - `omp` - Oh My Pi CLI
 - `fx` - fx.sh coding agent (`fx` starts an interactive session; `fx ask` runs one request)
+- `jcode` - J-Code coding agent (Claude Max / ChatGPT Pro subscriptions)
 
 **Precedence Rules:**
 

--- a/docs/_README.md
+++ b/docs/_README.md
@@ -19,7 +19,7 @@
 ## ✨ Features
 
 - **🔍 Fuzzy Search**: Interactive terminal UI with real-time filtering and keyboard navigation
-- **🔧 Auto-Detection**: Automatically finds installed AI CLIs (claude, cline, gemini, agy, opencode, amp, copilot, codex, interpreter, devin, kilo, kimi, mimo, pi, droid, ollama, cursor-agent, ccs, cmd, freebuff, grok)
+- **🔧 Auto-Detection**: Automatically finds installed AI CLIs (claude, cline, gemini, agy, opencode, amp, copilot, codex, interpreter, devin, kilo, kimi, mimo, pi, droid, ollama, cursor-agent, ccs, cmd, freebuff, grok, jcode)
 - **⚡ Direct Invocation**: Skip the menu with `ai <toolname>` or fuzzy matching
 - **🏷️ Aliases**: Define short aliases for frequently used tools (e.g., `ai c` for claude)
 - **📋 Templates**: Create command shortcuts with `$@` argument/stdin placeholders
@@ -446,6 +446,7 @@ The following CLIs are auto-detected if installed and available in PATH:
 - `cmd` - Command Code CLI
 - `freebuff` - Freebuff, free ad-supported AI coding agent (Codebuff variant)
 - `grok` - xAI Grok Build CLI
+- `jcode` - J-Code coding agent (Claude Max / ChatGPT Pro subscriptions)
 
 **Precedence Rules:**
 

--- a/docs/plans/2026-07-30-add-jcode-support.md
+++ b/docs/plans/2026-07-30-add-jcode-support.md
@@ -1,0 +1,36 @@
+# Plan: Add J-Code (`jcode`) launcher support
+
+**Date:** 2026-07-30  
+**Status:** Ready for PR
+
+## Goal
+
+Auto-detect and launch [J-Code](https://github.com/) (`jcode`) from `ai`, same as other known AI CLIs.
+
+## CLI facts (from `jcode --help` / `jcode run --help`)
+
+| Item | Value |
+|------|--------|
+| Binary | `jcode` (`/opt/homebrew/bin/jcode`) |
+| Version seen | `v0.64.2` |
+| Default launch | `jcode` (interactive TUI) |
+| One-shot | `jcode run <MESSAGE>` |
+| Description | Coding agent using Claude Max or ChatGPT Pro subscriptions |
+
+## Scope (confirmed)
+
+- **In:** Add to `KNOWN_TOOLS` for detect + interactive launch only
+- **Out:** `promptCommand` / `--diff` wiring; suggested-install list
+
+## Changes
+
+1. `src/detect.ts` — append `{ name, command, description }` for `jcode`
+2. `src/detect.test.ts` — config assertion test (pattern of `droid` / `pi`)
+3. `README.md` — list `jcode` in auto-detect blurb + supported tools section
+4. Branch + PR with commitizen message (`feat: …`)
+
+## Verification
+
+- `bun test src/detect.test.ts`
+- `bun run typecheck` / `bun run check`
+- Manual: `bun run src/index.ts jcode` when `jcode` is on PATH

--- a/docs/plans/2026-07-30-add-jcode-support.md
+++ b/docs/plans/2026-07-30-add-jcode-support.md
@@ -5,7 +5,7 @@
 
 ## Goal
 
-Auto-detect and launch [J-Code](https://github.com/) (`jcode`) from `ai`, same as other known AI CLIs.
+Auto-detect and launch [J-Code](https://github.com/1jehuang/jcode) (`jcode`) from `ai`, same as other known AI CLIs.
 
 ## CLI facts (from `jcode --help` / `jcode run --help`)
 

--- a/src/detect.test.ts
+++ b/src/detect.test.ts
@@ -314,7 +314,7 @@ describe("detectInstalledTools", () => {
   });
 
   test("jcode is in KNOWN_TOOLS with correct configuration", () => {
-    const jcode = KNOWN_TOOLS.find((t) => t.name === "jcode");
+    const jcode = KNOWN_TOOLS.find((t) => t.name === "jcode") as KnownToolDefinition | undefined;
 
     expect(jcode).toBeDefined();
     expect(jcode?.name).toBe("jcode");

--- a/src/detect.test.ts
+++ b/src/detect.test.ts
@@ -280,6 +280,16 @@ describe("detectInstalledTools", () => {
     expect(devin?.promptCommand).toBe("devin -p");
   });
 
+  test("jcode is in KNOWN_TOOLS with correct configuration", () => {
+    const jcode = KNOWN_TOOLS.find((t) => t.name === "jcode");
+
+    expect(jcode).toBeDefined();
+    expect(jcode?.name).toBe("jcode");
+    expect(jcode?.command).toBe("jcode");
+    expect(jcode?.description).toBe("J-Code - coding agent (Claude Max / ChatGPT Pro)");
+    expect(jcode?.promptCommand).toBeUndefined();
+  });
+
   test("returns only installed tools from KNOWN_TOOLS", () => {
     const tools = detectInstalledTools();
 

--- a/src/detect.test.ts
+++ b/src/detect.test.ts
@@ -313,6 +313,16 @@ describe("detectInstalledTools", () => {
     expect(devin?.promptCommand).toBe("devin -p");
   });
 
+  test("jcode is in KNOWN_TOOLS with correct configuration", () => {
+    const jcode = KNOWN_TOOLS.find((t) => t.name === "jcode");
+
+    expect(jcode).toBeDefined();
+    expect(jcode?.name).toBe("jcode");
+    expect(jcode?.command).toBe("jcode");
+    expect(jcode?.description).toBe("J-Code - coding agent (Claude Max / ChatGPT Pro)");
+    expect(jcode?.promptCommand).toBeUndefined();
+  });
+
   test("returns only installed tools from KNOWN_TOOLS", () => {
     const tools = detectInstalledTools();
 

--- a/src/detect.test.ts
+++ b/src/detect.test.ts
@@ -281,7 +281,7 @@ describe("detectInstalledTools", () => {
   });
 
   test("jcode is in KNOWN_TOOLS with correct configuration", () => {
-    const jcode = KNOWN_TOOLS.find((t) => t.name === "jcode");
+    const jcode = KNOWN_TOOLS.find((t) => t.name === "jcode") as KnownToolDefinition | undefined;
 
     expect(jcode).toBeDefined();
     expect(jcode?.name).toBe("jcode");

--- a/src/detect.ts
+++ b/src/detect.ts
@@ -149,6 +149,11 @@ export const KNOWN_TOOLS = [
     description: "fx.sh coding agent",
     promptCommand: "fx ask",
   },
+  {
+    name: "jcode",
+    command: "jcode",
+    description: "J-Code - coding agent (Claude Max / ChatGPT Pro)",
+  },
 ] as const satisfies readonly KnownToolDefinition[];
 
 export type KnownToolName = (typeof KNOWN_TOOLS)[number]["name"];

--- a/src/detect.ts
+++ b/src/detect.ts
@@ -130,6 +130,11 @@ export const KNOWN_TOOLS = [
     description: "Kimi Code - Moonshot AI CLI",
     promptCommand: "kimi -p",
   },
+  {
+    name: "jcode",
+    command: "jcode",
+    description: "J-Code - coding agent (Claude Max / ChatGPT Pro)",
+  },
 ] as const satisfies readonly KnownToolDefinition[];
 
 export type KnownToolName = (typeof KNOWN_TOOLS)[number]["name"];


### PR DESCRIPTION
## Summary
- Register `jcode` (J-Code) in `KNOWN_TOOLS` so the launcher auto-detects and launches it when on PATH
- Document support in README; plan notes in `docs/plans/2026-07-30-add-jcode-support.md`
- Detect + launch only (no `promptCommand` / `--diff` wiring yet)

## Test plan
- [x] `bun test src/detect.test.ts`
- [x] `bun run check`
- [ ] `bun run src/index.ts jcode` launches J-Code TUI when installed
- [ ] Fuzzy select shows `jcode` when binary is on PATH


Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added automatic detection for Reasonix, OMP, FX, and J-Code (`jcode`) AI tools.
  * Reasonix and OMP may now appear in suggested installation guidance.
  * Added FX support for generating prompts from Git diffs.
* **Documentation**
  * Updated feature descriptions, tool lists, configuration tables, and setup guidance for the newly supported AI tools.
  * Added planning and verification guidance for J-Code support.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->