### PR TITLE
feat: add Reasonix terminal agent support

### DIFF
--- a/.changeset/add-reasonix-tool.md
+++ b/.changeset/add-reasonix-tool.md
@@ -1,0 +1,7 @@
+---
+"ai-launcher": minor
+---
+
+Add reasonix tool auto-detection support
+
+Added reasonix to KNOWN_TOOLS for automatic detection when installed. Reasonix is a DeepSeek-native terminal coding agent (multi-model) that supports prompt-based launch via stdin (`reasonix run --stdin`), matching the existing pattern used by opencode/amp.

--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@
 ## ✨ Features
 
 - **🔍 Fuzzy Search**: Interactive terminal UI with real-time filtering and keyboard navigation
-- **🔧 Auto-Detection**: Automatically finds installed AI CLIs (claude, cline, gemini, agy, opencode, amp, copilot, codex, interpreter, devin, kilo, kimi, mimo, pi, droid, ollama, cursor-agent, ccs, cmd, freebuff, grok)
+- **🔧 Auto-Detection**: Automatically finds installed AI CLIs (claude, cline, gemini, agy, opencode, amp, copilot, codex, interpreter, devin, kilo, kimi, mimo, pi, droid, ollama, cursor-agent, ccs, cmd, freebuff, grok, reasonix)
 - **⚡ Direct Invocation**: Skip the menu with `ai <toolname>` or fuzzy matching
 - **🏷️ Aliases**: Define short aliases for frequently used tools (e.g., `ai c` for claude)
 - **📋 Templates**: Create command shortcuts with `$@` argument/stdin placeholders
@@ -446,6 +446,7 @@ The following CLIs are auto-detected if installed and available in PATH:
 - `cmd` - Command Code CLI
 - `freebuff` - Freebuff, free ad-supported AI coding agent (Codebuff variant)
 - `grok` - xAI Grok Build CLI
+- `reasonix` - Reasonix — DeepSeek-native terminal coding agent (multi-model)
 
 **Precedence Rules:**
 

--- a/docs/_README.md
+++ b/docs/_README.md
@@ -19,7 +19,7 @@
 ## ✨ Features
 
 - **🔍 Fuzzy Search**: Interactive terminal UI with real-time filtering and keyboard navigation
-- **🔧 Auto-Detection**: Automatically finds installed AI CLIs (claude, cline, gemini, agy, opencode, amp, copilot, codex, interpreter, devin, kilo, kimi, mimo, pi, droid, ollama, cursor-agent, ccs, cmd, freebuff, grok)
+- **🔧 Auto-Detection**: Automatically finds installed AI CLIs (claude, cline, gemini, agy, opencode, amp, copilot, codex, interpreter, devin, kilo, kimi, mimo, pi, droid, ollama, cursor-agent, ccs, cmd, freebuff, grok, reasonix)
 - **⚡ Direct Invocation**: Skip the menu with `ai <toolname>` or fuzzy matching
 - **🏷️ Aliases**: Define short aliases for frequently used tools (e.g., `ai c` for claude)
 - **📋 Templates**: Create command shortcuts with `$@` argument/stdin placeholders
@@ -446,6 +446,7 @@ The following CLIs are auto-detected if installed and available in PATH:
 - `cmd` - Command Code CLI
 - `freebuff` - Freebuff, free ad-supported AI coding agent (Codebuff variant)
 - `grok` - xAI Grok Build CLI
+- `reasonix` - Reasonix — DeepSeek-native terminal coding agent (multi-model)
 
 **Precedence Rules:**
 

--- a/src/detect.test.ts
+++ b/src/detect.test.ts
@@ -257,6 +257,19 @@ describe("detectInstalledTools", () => {
     expect(mimo?.promptCommand).toBe("mimo run");
   });
 
+  test("reasonix is in KNOWN_TOOLS with correct configuration", () => {
+    const reasonix = KNOWN_TOOLS.find((t) => t.name === "reasonix");
+
+    expect(reasonix).toBeDefined();
+    expect(reasonix?.name).toBe("reasonix");
+    expect(reasonix?.command).toBe("reasonix");
+    expect(reasonix?.description).toBe(
+      "Reasonix — DeepSeek-native terminal coding agent (multi-model)"
+    );
+    expect(reasonix?.promptCommand).toBe("reasonix run --stdin");
+    expect(reasonix?.promptUseStdin).toBe(true);
+  });
+
   test("interpreter is in KNOWN_TOOLS with correct configuration", () => {
     const interpreter = KNOWN_TOOLS.find((t) => t.name === "interpreter") as
       | KnownToolDefinition

--- a/src/detect.ts
+++ b/src/detect.ts
@@ -130,6 +130,13 @@ export const KNOWN_TOOLS = [
     description: "Kimi Code - Moonshot AI CLI",
     promptCommand: "kimi -p",
   },
+  {
+    name: "reasonix",
+    command: "reasonix",
+    description: "Reasonix — DeepSeek-native terminal coding agent (multi-model)",
+    promptCommand: "reasonix run --stdin",
+    promptUseStdin: true,
+  },
 ] as const satisfies readonly KnownToolDefinition[];
 
 export type KnownToolName = (typeof KNOWN_TOOLS)[number]["name"];
@@ -139,6 +146,7 @@ export const SUGGESTED_INSTALL_TOOL_NAMES = [
   "claude",
   "agy",
   "opencode",
+  "reasonix",
   "amp",
   "codex",
   "grok",


### PR DESCRIPTION
## What

Add support for the Reasonix CLI tool in KNOWN_TOOLS and suggested installs.

- Added Reasonix configuration in detect.ts:  command, description, promptCommand, and promptUseStdin
- Added a test asserting Reasonix entry in detect.test.ts
- Included Reasonix in SUGGESTED_INSTALL_TOOL_NAMES

## Why

Reasonix is a DeepSeek-native terminal coding agent, and ai-launcher needs to detect it alongside the other supported AI CLIs. Adding it here lets users discover and launch Reasonix without custom config.

## How

- Extend the static KNOWN_TOOLS list with a new entry
- Include it in the curated suggested install tooling order
- Add a focused unit test matching the existing detection-test pattern

## Checklist

- [x] Tests added or updated
- [ ] Documentation updated
- [ ] No breaking changes (or breaking changes documented above)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added automatic detection support for the Reasonix AI CLI.
  - Added Reasonix to suggested installation options.
  - Reasonix prompts can be sent through standard input.

- **Documentation**
  - Updated documentation to list Reasonix among supported and automatically detected AI tools.

- **Tests**
  - Added coverage verifying Reasonix detection and configuration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->