### PR TITLE
feat: add omp tool support

### DIFF
--- a/.changeset/add-omp-tool.md
+++ b/.changeset/add-omp-tool.md
@@ -1,0 +1,7 @@
+---
+"ai-launcher": minor
+---
+
+Add omp tool auto-detection support
+
+Added `omp` (Oh My Pi CLI) to `KNOWN_TOOLS` for automatic detection when installed.

--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@
 ## ✨ Features
 
 - **🔍 Fuzzy Search**: Interactive terminal UI with real-time filtering and keyboard navigation
-- **🔧 Auto-Detection**: Automatically finds installed AI CLIs (claude, cline, gemini, agy, opencode, amp, copilot, codex, interpreter, devin, kilo, kimi, mimo, pi, droid, ollama, cursor-agent, ccs, cmd, freebuff, grok, reasonix)
+- **🔧 Auto-Detection**: Automatically finds installed AI CLIs (claude, cline, gemini, agy, opencode, amp, copilot, codex, interpreter, devin, kilo, kimi, mimo, pi, droid, ollama, cursor-agent, ccs, cmd, freebuff, grok, reasonix, omp)
 - **⚡ Direct Invocation**: Skip the menu with `ai <toolname>` or fuzzy matching
 - **🏷️ Aliases**: Define short aliases for frequently used tools (e.g., `ai c` for claude)
 - **📋 Templates**: Create command shortcuts with `$@` argument/stdin placeholders
@@ -447,6 +447,7 @@ The following CLIs are auto-detected if installed and available in PATH:
 - `freebuff` - Freebuff, free ad-supported AI coding agent (Codebuff variant)
 - `grok` - xAI Grok Build CLI
 - `reasonix` - Reasonix — DeepSeek-native terminal coding agent (multi-model)
+- `omp` - Oh My Pi CLI
 
 **Precedence Rules:**
 

--- a/docs/_README.md
+++ b/docs/_README.md
@@ -19,7 +19,7 @@
 ## ✨ Features
 
 - **🔍 Fuzzy Search**: Interactive terminal UI with real-time filtering and keyboard navigation
-- **🔧 Auto-Detection**: Automatically finds installed AI CLIs (claude, cline, gemini, agy, opencode, amp, copilot, codex, interpreter, devin, kilo, kimi, mimo, pi, droid, ollama, cursor-agent, ccs, cmd, freebuff, grok, reasonix)
+- **🔧 Auto-Detection**: Automatically finds installed AI CLIs (claude, cline, gemini, agy, opencode, amp, copilot, codex, interpreter, devin, kilo, kimi, mimo, pi, droid, ollama, cursor-agent, ccs, cmd, freebuff, grok, reasonix, omp)
 - **⚡ Direct Invocation**: Skip the menu with `ai <toolname>` or fuzzy matching
 - **🏷️ Aliases**: Define short aliases for frequently used tools (e.g., `ai c` for claude)
 - **📋 Templates**: Create command shortcuts with `$@` argument/stdin placeholders
@@ -447,6 +447,7 @@ The following CLIs are auto-detected if installed and available in PATH:
 - `freebuff` - Freebuff, free ad-supported AI coding agent (Codebuff variant)
 - `grok` - xAI Grok Build CLI
 - `reasonix` - Reasonix — DeepSeek-native terminal coding agent (multi-model)
+- `omp` - Oh My Pi CLI
 
 **Precedence Rules:**
 

--- a/src/detect.test.ts
+++ b/src/detect.test.ts
@@ -270,6 +270,16 @@ describe("detectInstalledTools", () => {
     expect(reasonix?.promptUseStdin).toBe(true);
   });
 
+  test("omp is in KNOWN_TOOLS with correct configuration", () => {
+    const omp = KNOWN_TOOLS.find((t) => t.name === "omp");
+
+    expect(omp).toBeDefined();
+    expect(omp?.name).toBe("omp");
+    expect(omp?.command).toBe("omp");
+    expect(omp?.description).toBe("Oh My Pi CLI");
+    expect(omp?.promptCommand).toBe("omp -p");
+  });
+
   test("interpreter is in KNOWN_TOOLS with correct configuration", () => {
     const interpreter = KNOWN_TOOLS.find((t) => t.name === "interpreter") as
       | KnownToolDefinition

--- a/src/detect.ts
+++ b/src/detect.ts
@@ -137,6 +137,12 @@ export const KNOWN_TOOLS = [
     promptCommand: "reasonix run --stdin",
     promptUseStdin: true,
   },
+  {
+    name: "omp",
+    command: "omp",
+    description: "Oh My Pi CLI",
+    promptCommand: "omp -p",
+  },
 ] as const satisfies readonly KnownToolDefinition[];
 
 export type KnownToolName = (typeof KNOWN_TOOLS)[number]["name"];
@@ -153,6 +159,7 @@ export const SUGGESTED_INSTALL_TOOL_NAMES = [
   "kimi",
   "ollama",
   "mimo",
+  "omp",
 ] as const satisfies readonly KnownToolName[];
 
 export type SuggestedInstallTool = {


### PR DESCRIPTION
## What

Add `omp` (Oh My Pi CLI) to auto-detected tools list (`KNOWN_TOOLS`) and suggested installation tools (`SUGGESTED_INSTALL_TOOL_NAMES`).

## Why

Users who have `omp` installed can now automatically detect and select `omp` in `ai-launcher` interactive TUI or invoke it directly with `ai omp`.

## How

- Added `omp` tool entry to `KNOWN_TOOLS` in `src/detect.ts` with `promptCommand: "omp -p"`
- Added `"omp"` to `SUGGESTED_INSTALL_TOOL_NAMES` for fallback suggestions when no AI tools are installed
- Added unit test in `src/detect.test.ts` verifying `omp` tool configuration
- Updated `README.md` and `docs/_README.md` auto-detection tool lists
- Added changeset `.changeset/add-omp-tool.md`

## Checklist

- [x] Tests added or updated
- [x] Documentation updated
- [x] No breaking changes (or breaking changes documented above)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added automatic detection and support for the Oh My Pi CLI (`omp`).
  * Included `omp` in suggested installation options and prompt command handling.

* **Documentation**
  * Updated the README and detailed documentation with `omp` detection information.

* **Tests**
  * Added coverage confirming the `omp` tool configuration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->